### PR TITLE
Implement Julian Calendar

### DIFF
--- a/hodatime.cabal
+++ b/hodatime.cabal
@@ -124,6 +124,7 @@ test-suite test
                    HodaTime.DurationTest,
                    HodaTime.OffsetTest,
                    HodaTime.Calendar.GregorianTest,
+                   HodaTime.Calendar.JulianTest,
                    HodaTime.CalendarDateTimeTest,
                    HodaTime.ZonedDateTimeTest,
                    HodaTime.PatternTest

--- a/src/Data/HodaTime/Calendar/Coptic.hs
+++ b/src/Data/HodaTime/Calendar/Coptic.hs
@@ -7,7 +7,10 @@
 -- Stability   :  experimental
 -- Portability :  POSIX, Windows
 --
--- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Coptic' calendar.
+-- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Coptic' calendar, the liturgical calendar of the Coptic Orthodox Church whose era of the Martyrs counts years from 284 CE.  It
+-- has twelve months of 30 days followed by a short thirteenth month of five days (six in a leap year) and uses the same every-fourth-year leap rule as 'Data.HodaTime.Calendar.Julian'.
+--
+-- Note: this calendar is not yet implemented.
 ----------------------------------------------------------------------------
 module Data.HodaTime.Calendar.Coptic
 (

--- a/src/Data/HodaTime/Calendar/Gregorian.hs
+++ b/src/Data/HodaTime/Calendar/Gregorian.hs
@@ -7,7 +7,12 @@
 -- Stability   :  experimental
 -- Portability :  POSIX, Windows
 --
--- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Gregorian' calendar.
+-- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Gregorian' calendar, the civil calendar used across most of the world today.  The Gregorian calendar refines the Julian leap
+-- year rule: every fourth year is a leap year, except that a century year (one divisible by 100) is a leap year only when it is also divisible by 400.  Those century exceptions keep the calendar
+-- closely aligned to the solar year and correct the slow drift of 'Data.HodaTime.Calendar.Julian' (which gains roughly three days every four centuries).  Unlike some libraries this calendar is not
+-- proleptic: because the Gregorian calendar first took effect on 15 October 1582 (the day after 4 October 1582 in the Julian calendar, when ten days were dropped) this implementation rejects any
+-- earlier date \- use 'Data.HodaTime.Calendar.Julian' for dates before the changeover.  The Gregorian calendar anchors the absolute timeline that every other calendar is measured against, so a given
+-- instant's Gregorian date is the reference that the other calendars are offset from.
 ----------------------------------------------------------------------------
 module Data.HodaTime.Calendar.Gregorian
 (
@@ -31,7 +36,7 @@ import Control.Monad (guard)
 
 -- TODO: smart constructors hard coded to Maybe, make them like LocalTime
 
--- | Smart constuctor for Gregorian calendar date.
+-- | Smart constructor for a 'Gregorian' calendar date.  Returns 'Nothing' if the day is out of range for the given month and year, or if the date falls before the 15 October 1582 changeover.
 calendarDate :: DayOfMonth -> Month Gregorian -> Year -> Maybe (CalendarDate Gregorian)
 calendarDate d m y = do
   guard $ d > 0 && d <= maxDaysInMonth m y
@@ -39,7 +44,7 @@ calendarDate d m y = do
   guard $ gregorianToDays gd > invalidDayThresh
   return gd
 
--- | Smart constuctor for Gregorian calendar date based on relative month day.
+-- | Smart constructor for a 'Gregorian' calendar date given as a day relative to a month (e.g. the third Monday of the month).  Returns 'Nothing' if the resulting date is invalid.
 fromNthDay :: DayNth -> DayOfWeek Gregorian -> Month Gregorian -> Year -> Maybe (CalendarDate Gregorian)
 fromNthDay nth dow m y = do
   guard $ d > 0 && d <= mdim
@@ -51,7 +56,7 @@ fromNthDay nth dow m y = do
     d = nthDayToDayOfMonth nth' (fromEnum dow) m y
     days = yearMonthDayToDays y m d
 
--- | Smart constuctor for Gregorian calendar date based on week date.  Note that this method assumes weeks start on Sunday and the first week of the year is the one
+-- | Smart constructor for a 'Gregorian' calendar date given as a week date.  Note that this method assumes weeks start on Sunday and the first week of the year is the one
 --   which has at least one day in the new year.  For ISO compliant behavior use this constructor from the ISO module
 fromWeekDate :: WeekNumber -> DayOfWeek Gregorian -> Year -> Maybe (CalendarDate Gregorian)
 fromWeekDate = GI.fromWeekDate 1 Sunday

--- a/src/Data/HodaTime/Calendar/Gregorian.hs
+++ b/src/Data/HodaTime/Calendar/Gregorian.hs
@@ -29,6 +29,7 @@ where
 
 import Data.HodaTime.Calendar.Gregorian.Internal hiding (fromWeekDate)
 import Data.HodaTime.CalendarDateTime.Internal (CalendarDate, DayNth, DayOfMonth, Year, WeekNumber)
+import Data.HodaTime.Calendar.Internal (mkFromNthDay)
 import qualified Data.HodaTime.Calendar.Gregorian.Internal as GI
 import Control.Monad (guard)
 
@@ -46,15 +47,7 @@ calendarDate d m y = do
 
 -- | Smart constructor for a 'Gregorian' calendar date given as a day relative to a month (e.g. the third Monday of the month).  Returns 'Nothing' if the resulting date is invalid.
 fromNthDay :: DayNth -> DayOfWeek Gregorian -> Month Gregorian -> Year -> Maybe (CalendarDate Gregorian)
-fromNthDay nth dow m y = do
-  guard $ d > 0 && d <= mdim
-  guard $ days > invalidDayThresh
-  return $ daysToGregorian (fromIntegral days)
-  where
-    nth' = fromEnum nth - 4
-    mdim = maxDaysInMonth m y
-    d = nthDayToDayOfMonth nth' (fromEnum dow) m y
-    days = yearMonthDayToDays y m d
+fromNthDay = mkFromNthDay invalidDayThresh epochDayOfWeek yearMonthDayToDays maxDaysInMonth daysToGregorian
 
 -- | Smart constructor for a 'Gregorian' calendar date given as a week date.  Note that this method assumes weeks start on Sunday and the first week of the year is the one
 --   which has at least one day in the new year.  For ISO compliant behavior use this constructor from the ISO module

--- a/src/Data/HodaTime/Calendar/Gregorian/Internal.hs
+++ b/src/Data/HodaTime/Calendar/Gregorian/Internal.hs
@@ -24,13 +24,12 @@ where
 
 import Data.HodaTime.CalendarDateTime.Internal (IsCalendar(..), IsCalendarDateTime(..), DayOfMonth, Year, WeekNumber, CalendarDateTime(..), LocalTime(..), Date)
 import Data.HodaTime.Calendar.Gregorian.CacheTable (DTCacheTable(..), decodeMonth, decodeYear, decodeDay, cacheTable)
-import Data.HodaTime.Calendar.Internal (mkCommonMonthLens, mkYearLens, dayOfWeekFromDays, commonMonthDayOffsets, borders, daysPerStandardYear, daysPerCentury)
+import Data.HodaTime.Calendar.Internal (mkCommonMonthLens, mkYearLens, mkFromWeekDate, dayOfWeekFromDays, commonMonthDayOffsets, borders, daysPerStandardYear, daysPerCentury)
 import Data.HodaTime.Instant.Internal (Instant(..))
 import Control.Arrow ((>>>), (&&&), (***), first)
 import Data.Int (Int32, Int8)
 import Data.Word (Word8, Word32)
 import Data.Array.Unboxed ((!))
-import Control.Monad (guard)
 
 -- Constants
 
@@ -103,30 +102,20 @@ instance IsCalendarDateTime Gregorian where
 -- constructors
 
 fromWeekDate :: Int -> DayOfWeek Gregorian -> WeekNumber -> DayOfWeek Gregorian -> Year -> Maybe (Date Gregorian)
-fromWeekDate minWeekDays wkStartDoW weekNum dow y = do
-  guard $ days > invalidDayThresh
-  return $ daysToGregorian days
-    where
-      soyDays = yearMonthDayToDays y January minWeekDays
-      soyDoW = dayOfWeekFromDays epochDayOfWeek soyDays
-      startDoWDistance = fromEnum soyDoW - fromEnum wkStartDoW
-      dowDistance = fromEnum dow - fromEnum wkStartDoW
-      dowDistance' = if dowDistance < 0 then dowDistance + 7 else dowDistance
-      startDays = soyDays - startDoWDistance
-      weekNum' = pred weekNum
-      days = fromIntegral $ startDays + weekNum' * 7 + dowDistance'
+fromWeekDate = mkFromWeekDate invalidDayThresh epochDayOfWeek yearMonthDayToDays daysToGregorian
 
 -- helper functions
 
 nthDayToDayOfMonth :: Int -> Int -> Month Gregorian -> Int -> Int
-nthDayToDayOfMonth nth day month y = dom + d' + 7 * nth
+nthDayToDayOfMonth nth day month y
+  | nth < 0   = mdm - backwardDist + 7 * (nth + 1)      -- NOTE: "from last" (POSIX week 5 -> nth -1) counts back from the last day, so the final weekday is not missed when the month ends exactly on it
+  | otherwise = 1   + forwardDist  + 7 * nth
   where
     mdm = maxDaysInMonth month y
-    dom = if nth < 0 then mdm else 1
+    forwardDist  = (day - dowOf 1)   `mod` 7
+    backwardDist = (dowOf mdm - day) `mod` 7
+    dowOf dom = (dom + (13 * m' - 1) `div` 5 + yrhs + (yrhs `div` 4) + (ylhs `div` 4) - 2 * ylhs) `mod` 7
     m = fromEnum month
-    dow = (dom + (13 * m' - 1) `div` 5 + yrhs + (yrhs `div` 4) + (ylhs `div` 4) - 2 * ylhs) `mod` 7
-    d = day - dow
-    d' = if d < 0 then d + 7 else d
     (m', y') = if m < 2 then (m + 11, y - 1) else (m - 1, y)
     yrhs = y' `mod` 100
     ylhs = y' `div` 100

--- a/src/Data/HodaTime/Calendar/Hebrew.hs
+++ b/src/Data/HodaTime/Calendar/Hebrew.hs
@@ -7,7 +7,10 @@
 -- Stability   :  experimental
 -- Portability :  POSIX, Windows
 --
--- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Hebrew' calendar.
+-- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Hebrew' (Jewish) calendar, a lunisolar calendar that keeps its months in step with the solar year by inserting a leap month
+-- seven times in each 19-year Metonic cycle.  Months can be counted in either the civil or the scriptural convention (see 'HebrewMonthNumbering').
+--
+-- Note: this calendar is not yet implemented.
 ----------------------------------------------------------------------------
 module Data.HodaTime.Calendar.Hebrew
 (

--- a/src/Data/HodaTime/Calendar/Internal.hs
+++ b/src/Data/HodaTime/Calendar/Internal.hs
@@ -5,6 +5,8 @@ module Data.HodaTime.Calendar.Internal
    mkCommonDayLens
   ,mkCommonMonthLens
   ,mkYearLens
+  ,mkFromNthDay
+  ,mkFromWeekDate
   ,moveByDow
   ,dayOfWeekFromDays
   ,commonMonthDayOffsets
@@ -15,10 +17,11 @@ module Data.HodaTime.Calendar.Internal
 )
 where
 
-import Data.HodaTime.CalendarDateTime.Internal (Year, DayOfMonth)
+import Data.HodaTime.CalendarDateTime.Internal (Year, DayOfMonth, DayNth, WeekNumber)
 import Data.Int (Int32)
 import Data.Word (Word8, Word32)
 import Control.Arrow ((>>>), first)
+import Control.Monad (guard)
 
 -- Constants
 
@@ -94,6 +97,60 @@ mkYearLens firstDayTuple maxDaysInMonth yearMonthDayToDays toYmd fromDays f date
           d'' = if d' > mdim then mdim else d'
           days = fromIntegral $ yearMonthDayToDays y'' m'' (fromIntegral d'')
 {-# INLINE mkYearLens #-}
+
+-- | Build a date from the nth (or nth-from-last) weekday within a month (e.g. \"the third Monday\").  This is the
+--   calendar-agnostic core of a per-calendar @fromNthDay@: it reads the weekday of the anchor day (the 1st, or the
+--   last day of the month for a \"from last\" request) via the calendar's own day count, so it needs no per-calendar
+--   weekday formula.
+mkFromNthDay :: (Enum mon, Enum dow) =>
+     Int                                   -- ^ invalid-day threshold (dates on or before this are rejected)
+  -> dow                                   -- ^ epoch day of week
+  -> (Year -> mon -> DayOfMonth -> Int)    -- ^ yearMonthDayToDays
+  -> (mon -> Year -> Int)                  -- ^ maxDaysInMonth
+  -> (Int32 -> d)                          -- ^ fromDays
+  -> DayNth -> dow -> mon -> Year -> Maybe d
+mkFromNthDay invalidDayThresh epochDayOfWeek yearMonthDayToDays maxDaysInMonth fromDays nth dow m y = do
+  guard $ d > 0 && d <= mdim
+  guard $ days > invalidDayThresh
+  return $ fromDays (fromIntegral days)
+    where
+      nth' = fromEnum nth - 4
+      mdim = maxDaysInMonth m y
+      target = fromEnum dow
+      -- forward (nth' >= 0) counts from the first of the month; \"from last\" (nth' < 0) counts back from the last day.
+      -- Using the backward distance for the from-last case is what makes \"the last Friday\" land on the final Friday
+      -- even when the month ends exactly on that weekday (where a naive forward offset would be a week short).
+      d | nth' < 0  = mdim - backwardDist + 7 * (nth' + 1)
+        | otherwise = 1    + forwardDist  + 7 * nth'
+      forwardDist  = (target - dowOf 1)    `mod` 7
+      backwardDist = (dowOf mdim - target) `mod` 7
+      dowOf dom = dayOfWeekFromDays epochDayOfWeek (yearMonthDayToDays y m dom)
+      days = yearMonthDayToDays y m d
+{-# INLINE mkFromNthDay #-}
+
+-- | Build a date from a week-numbering rule.  @minWeekDays@ and @weekStart@ define the rule (e.g. @1 Sunday@ for the
+--   simple rule where week 1 is the first week with any day in the new year, or @4 Monday@ for ISO-8601).  This is the
+--   calendar-agnostic core of a per-calendar @fromWeekDate@.
+mkFromWeekDate :: (Enum mon, Enum dow) =>
+     Int                                   -- ^ invalid-day threshold
+  -> dow                                   -- ^ epoch day of week
+  -> (Year -> mon -> DayOfMonth -> Int)    -- ^ yearMonthDayToDays
+  -> (Int32 -> d)                          -- ^ fromDays
+  -> Int                                   -- ^ minimum days of the new year that fall in week 1
+  -> dow                                   -- ^ first day of the week
+  -> WeekNumber -> dow -> Year -> Maybe d
+mkFromWeekDate invalidDayThresh epochDayOfWeek yearMonthDayToDays fromDays minWeekDays wkStartDoW weekNum dow y = do
+  guard $ days > invalidDayThresh
+  return $ fromDays (fromIntegral days)
+    where
+      soyDays = yearMonthDayToDays y (toEnum 0) minWeekDays
+      soyDoW = dayOfWeekFromDays epochDayOfWeek soyDays
+      startDoWDistance = soyDoW - fromEnum wkStartDoW
+      dowDistance = fromEnum dow - fromEnum wkStartDoW
+      dowDistance' = if dowDistance < 0 then dowDistance + 7 else dowDistance
+      startDays = soyDays - startDoWDistance
+      days = startDays + pred weekNum * 7 + dowDistance'
+{-# INLINE mkFromWeekDate #-}
 
 moveByDow :: Enum dow =>
      (Int32 -> d)

--- a/src/Data/HodaTime/Calendar/Islamic.hs
+++ b/src/Data/HodaTime/Calendar/Islamic.hs
@@ -7,7 +7,11 @@
 -- Stability   :  experimental
 -- Portability :  POSIX, Windows
 --
--- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Islamic' calendar.
+-- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Islamic' (Hijri) calendar, a purely lunar calendar of twelve alternating 30- and 29-day months.  Its year is about eleven days
+-- shorter than the solar year, so its dates drift through the seasons.  The tabular form approximates the observed calendar with a 30-year leap cycle; the exact leap years and the starting epoch are
+-- selectable (see 'IslamicLeapYearPattern' and 'IslamicEpoch').
+--
+-- Note: this calendar is not yet implemented.
 ----------------------------------------------------------------------------
 module Data.HodaTime.Calendar.Islamic
 (

--- a/src/Data/HodaTime/Calendar/Iso.hs
+++ b/src/Data/HodaTime/Calendar/Iso.hs
@@ -7,7 +7,10 @@
 -- Stability   :  experimental
 -- Portability :  POSIX, Windows
 --
--- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Iso' 8601 calendar.  This calendar is the same as the 'Gregorian' calendar except for how week dates are calculated.
+-- This is the module for 'CalendarDate' and 'CalendarDateTime' in the ISO 8601 calendar.  For every date the ISO calendar is identical to 'Data.HodaTime.Calendar.Gregorian' \- the same months, the
+-- same leap year rule and the same 15 October 1582 cut-off \- and it reuses the Gregorian types directly.  The two differ only in how week dates are numbered: ISO weeks start on Monday and week 1 is
+-- the first week containing at least four days of the new year (equivalently, the week holding that year's first Thursday).  Use this module's 'fromWeekDate' for ISO-8601 week numbering; the Gregorian
+-- module provides the alternative Sunday-based, at-least-one-day rule.
 ----------------------------------------------------------------------------
 module Data.HodaTime.Calendar.Iso
 (
@@ -19,7 +22,7 @@ import Data.HodaTime.Calendar.Gregorian.Internal hiding (fromWeekDate)
 import qualified Data.HodaTime.Calendar.Gregorian.Internal as GI
 import Data.HodaTime.CalendarDateTime.Internal (CalendarDate, Year, WeekNumber)
 
--- | Smart constuctor for ISO calendar date based day within year week.  Note that this method assumes weeks start on Monday and the first week of the year is the one
+-- | Smart constructor for an ISO 8601 week date.  Note that this method assumes weeks start on Monday and the first week of the year is the one
 --   which has at least four days in the new year.  See the Gregorian module for alternative behavior
 fromWeekDate :: WeekNumber -> DayOfWeek Gregorian -> Year -> Maybe (CalendarDate Gregorian)
 fromWeekDate = GI.fromWeekDate 4 Monday

--- a/src/Data/HodaTime/Calendar/Julian.hs
+++ b/src/Data/HodaTime/Calendar/Julian.hs
@@ -9,7 +9,8 @@
 -- Portability :  POSIX, Windows
 --
 -- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Julian' calendar.  The calendar is proleptic in that, while it does start in 45 BC it does not try to account for the fact
--- that before around 4 AD the leap year rule was accidentally implemented as a leap year every three years.
+-- that before around 4 AD the leap year rule was accidentally implemented as a leap year every three years.  This implementation stores the year unsigned, so its supported range is AD 1 onward
+-- (BC years are not representable).  Dates share the same absolute timeline as every other calendar, so in the modern era a Julian date reads 13 days behind the same instant's Gregorian date.
 ----------------------------------------------------------------------------
 module Data.HodaTime.Calendar.Julian
 (
@@ -37,18 +38,34 @@ import Data.List (findIndex)
 
 -- constants
 
-invalidDayThresh :: Integral a => a
-invalidDayThresh = -152445      -- NOTE: 14.Oct.1582, one day before Gregorian calendar came into effect
-
+-- | The Julian calendar predates the Gregorian one, so \- unlike 'Data.HodaTime.Calendar.Gregorian', which is only
+--   valid from 15.Oct.1582 \- there is no reason to reject earlier dates here: rejecting pre\-1582 dates is exactly
+--   what the Julian calendar exists to represent.  We floor at 1.Jan.AD 1 because the decoded year is stored unsigned
+--   ('toYmd' returns a 'Word32' year), so BC years are not representable in this implementation.
 firstJulDayTuple :: (Integral a, Integral b, Integral c) => (a, b, c)
-firstJulDayTuple = (1582, 9, 15)
- 
+firstJulDayTuple = (1, 0, 1)        -- NOTE: 1.Jan.AD 1
+
+invalidDayThresh :: Integral a => a
+invalidDayThresh = fromIntegral $ pred day0
+  where
+    (y, m, d) = firstJulDayTuple :: (Year, Int, DayOfMonth)
+    day0 = yearMonthDayToDays y (toEnum m) d
+
 epochDayOfWeek :: DayOfWeek Julian
 epochDayOfWeek = Wednesday
 
+-- | The Julian and (proleptic) Gregorian calendars diverge, so they cannot share a flat day 0 that is a clean date in
+--   both.  'Data.HodaTime.Calendar.Gregorian' owns the shared absolute epoch (flat day 0 = 1.Mar.2000 Gregorian), which
+--   the Julian calendar labels 17.Feb.2000.  Julian's own clean epoch (1.Mar.2000 Julian) sits 13 days later on that
+--   shared timeline, so we shift the internal Julian day count by this constant to place it on the same absolute
+--   timeline as every other calendar.  Because it is the gap between two fixed absolute days, the shift is constant for
+--   all of time.
+julianEpochShift :: Num a => a
+julianEpochShift = 13
+
 -- In case we ever decide to generate a 28 year table to store cycles
 -- daysPerSolarCycle :: Num a => a
--- daysPerSolarCycle = 10227
+-- daysPerSolarCycle = 10227     -- NOTE: 28 Julian years = 10227 days = 1461 * 7 weeks exactly (dates and weekdays repeat)
 
 -- types
     
@@ -128,11 +145,12 @@ yearMonthDayToDays y m d = days
     m' = if m > February then fromEnum m - 2 else fromEnum m + 10
     years = if m < March then y - 2001 else y - 2000
     yearDays = years * daysPerStandardYear + years `div` 4
-    days = yearDays + commonMonthDayOffsets !! m' + d - 1
+    days = yearDays + commonMonthDayOffsets !! m' + d - 1 + julianEpochShift
 
 daysToYearMonthDay :: Int32 -> (Word32, Word8, Word8)
-daysToYearMonthDay days = (fromIntegral y, fromIntegral m'', fromIntegral d')
+daysToYearMonthDay days0 = (fromIntegral y, fromIntegral m'', fromIntegral d')
   where
+    days = days0 - julianEpochShift
     (fourYears, (remaining, isLeapDay)) = flip divMod daysPerFourYears >>> (* 4) *** id &&& borders daysPerFourYears $ days
     (oneYears, yearDays) = remaining `divMod` daysPerStandardYear
     -- NOTE: the sentinel 'daysPerStandardYear' lets February (yearDays >= the last real offset) be found; without it

--- a/src/Data/HodaTime/Calendar/Julian.hs
+++ b/src/Data/HodaTime/Calendar/Julian.hs
@@ -14,23 +14,24 @@
 module Data.HodaTime.Calendar.Julian
 (
   -- * Constructors
-  -- calendarDate
+   calendarDate
   --,fromNthDay
   --,fromWeekDate
   -- * Types
-   Month(..)
+  ,Month(..)
   ,DayOfWeek(..)
   ,Julian
   ,yearMonthDayToDays
 )
 where
 
-import Data.HodaTime.CalendarDateTime.Internal (IsCalendar(..), IsCalendarDateTime(..), DayOfMonth, Year, CalendarDateTime(..), LocalTime(..), Date)
+import Data.HodaTime.CalendarDateTime.Internal (IsCalendar(..), IsCalendarDateTime(..), CalendarDate, DayOfMonth, Year, CalendarDateTime(..), LocalTime(..), Date)
 import Data.HodaTime.Instant.Internal (Instant(..))
 import Data.HodaTime.Calendar.Internal (mkCommonDayLens, mkCommonMonthLens, mkYearLens, moveByDow, dayOfWeekFromDays, commonMonthDayOffsets, borders, daysPerStandardYear, daysPerFourYears)
 import Data.Int (Int32)
 import Data.Word (Word8, Word32)
 import Control.Arrow ((>>>), (***), (&&&))
+import Control.Monad (guard)
 import Data.Maybe (fromJust)
 import Data.List (findIndex)
 
@@ -99,6 +100,16 @@ julianToDays (JulianDate days _ _ _) = days
 julianToYmd :: Date Julian -> (Word32, Word8, Word8)
 julianToYmd (JulianDate _ d m y) = (y, m, d)
 
+-- Constructors
+
+-- | Smart constructor for a 'Julian' calendar date.
+calendarDate :: DayOfMonth -> Month Julian -> Year -> Maybe (CalendarDate Julian)
+calendarDate d m y = do
+  guard $ d > 0 && d <= maxDaysInMonth m y
+  let days = fromIntegral $ yearMonthDayToDays y m d
+  guard $ days > invalidDayThresh
+  return $ julianFromDays days
+
 -- helper functions
 
 maxDaysInMonth :: Month Julian -> Year -> Int
@@ -124,7 +135,9 @@ daysToYearMonthDay days = (fromIntegral y, fromIntegral m'', fromIntegral d')
   where
     (fourYears, (remaining, isLeapDay)) = flip divMod daysPerFourYears >>> (* 4) *** id &&& borders daysPerFourYears $ days
     (oneYears, yearDays) = remaining `divMod` daysPerStandardYear
-    m = pred . fromJust . findIndex (\mo -> yearDays < mo) $ commonMonthDayOffsets
+    -- NOTE: the sentinel 'daysPerStandardYear' lets February (yearDays >= the last real offset) be found; without it
+    -- 'findIndex' returns Nothing and 'fromJust' crashes for any late-February date.
+    m = pred . fromJust . findIndex (\mo -> yearDays < mo) $ commonMonthDayOffsets ++ [daysPerStandardYear]
     (m', startDate) = if m >= 10 then (m - 10, 2001) else (m + 2, 2000)
     d = yearDays - commonMonthDayOffsets !! m + 1
     (m'', d') = if isLeapDay then (1, 29) else (m', d)

--- a/src/Data/HodaTime/Calendar/Julian.hs
+++ b/src/Data/HodaTime/Calendar/Julian.hs
@@ -8,9 +8,11 @@
 -- Stability   :  experimental
 -- Portability :  POSIX, Windows
 --
--- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Julian' calendar.  The calendar is proleptic in that, while it does start in 45 BC it does not try to account for the fact
--- that before around 4 AD the leap year rule was accidentally implemented as a leap year every three years.  This implementation stores the year unsigned, so its supported range is AD 1 onward
--- (BC years are not representable).  Dates share the same absolute timeline as every other calendar, so in the modern era a Julian date reads 13 days behind the same instant's Gregorian date.
+-- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Julian' calendar.  The Julian calendar has a simple leap year rule \- every fourth year is a leap year, with none of the
+-- century exceptions that 'Data.HodaTime.Calendar.Gregorian' later added to keep the calendar aligned to the solar year.  It is proleptic in that, while it only started in 45 BC, this
+-- implementation applies that rule uniformly and does not try to account for the fact that before around 4 AD the leap year rule was accidentally implemented as a leap year every three years.  This
+-- implementation stores the year unsigned, so its supported range is AD 1 onward (BC years are not representable).  Dates share the same absolute timeline as every other calendar, so in the modern
+-- era a Julian date reads 13 days behind the same instant's Gregorian date.
 ----------------------------------------------------------------------------
 module Data.HodaTime.Calendar.Julian
 (

--- a/src/Data/HodaTime/Calendar/Julian.hs
+++ b/src/Data/HodaTime/Calendar/Julian.hs
@@ -18,8 +18,8 @@ module Data.HodaTime.Calendar.Julian
 (
   -- * Constructors
    calendarDate
-  --,fromNthDay
-  --,fromWeekDate
+  ,fromNthDay
+  ,fromWeekDate
   -- * Types
   ,Month(..)
   ,DayOfWeek(..)
@@ -27,9 +27,9 @@ module Data.HodaTime.Calendar.Julian
 )
 where
 
-import Data.HodaTime.CalendarDateTime.Internal (IsCalendar(..), IsCalendarDateTime(..), CalendarDate, DayOfMonth, Year, CalendarDateTime(..), LocalTime(..), Date)
+import Data.HodaTime.CalendarDateTime.Internal (IsCalendar(..), IsCalendarDateTime(..), CalendarDate, DayNth, DayOfMonth, Year, WeekNumber, CalendarDateTime(..), LocalTime(..), Date)
 import Data.HodaTime.Instant.Internal (Instant(..))
-import Data.HodaTime.Calendar.Internal (mkCommonDayLens, mkCommonMonthLens, mkYearLens, moveByDow, dayOfWeekFromDays, commonMonthDayOffsets, borders, daysPerStandardYear, daysPerFourYears)
+import Data.HodaTime.Calendar.Internal (mkCommonDayLens, mkCommonMonthLens, mkYearLens, mkFromNthDay, mkFromWeekDate, moveByDow, dayOfWeekFromDays, commonMonthDayOffsets, borders, daysPerStandardYear, daysPerFourYears)
 import Data.Int (Int32)
 import Data.Word (Word8, Word32)
 import Control.Arrow ((>>>), (***), (&&&))
@@ -127,6 +127,15 @@ calendarDate d m y = do
   let days = fromIntegral $ yearMonthDayToDays y m d
   guard $ days > invalidDayThresh
   return $ julianFromDays days
+
+-- | Smart constructor for a 'Julian' calendar date given as a day relative to a month (e.g. the third Monday of the month).  Returns 'Nothing' if the resulting date is invalid.
+fromNthDay :: DayNth -> DayOfWeek Julian -> Month Julian -> Year -> Maybe (CalendarDate Julian)
+fromNthDay = mkFromNthDay invalidDayThresh epochDayOfWeek yearMonthDayToDays maxDaysInMonth julianFromDays
+
+-- | Smart constructor for a 'Julian' calendar date given as a week date.  Note that this method assumes weeks start on Sunday and the first week of the year is the one
+--   which has at least one day in the new year.
+fromWeekDate :: WeekNumber -> DayOfWeek Julian -> Year -> Maybe (CalendarDate Julian)
+fromWeekDate = mkFromWeekDate invalidDayThresh epochDayOfWeek yearMonthDayToDays julianFromDays 1 Sunday
 
 -- helper functions
 

--- a/src/Data/HodaTime/Calendar/Julian.hs
+++ b/src/Data/HodaTime/Calendar/Julian.hs
@@ -24,7 +24,6 @@ module Data.HodaTime.Calendar.Julian
   ,Month(..)
   ,DayOfWeek(..)
   ,Julian
-  ,yearMonthDayToDays
 )
 where
 

--- a/src/Data/HodaTime/Calendar/Persian.hs
+++ b/src/Data/HodaTime/Calendar/Persian.hs
@@ -7,7 +7,11 @@
 -- Stability   :  experimental
 -- Portability :  POSIX, Windows
 --
--- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Persian' calendar.
+-- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Persian' (Solar Hijri) calendar, the official calendar of Iran and Afghanistan.  It is a solar calendar whose year begins at the
+-- vernal equinox and whose leap years are among the most accurate of any calendar; they can be found from a simple 33-year cycle, from Birashk's nested arithmetic cycles, or from astronomical
+-- calculation of the equinox.
+--
+-- Note: this calendar is not yet implemented.
 ----------------------------------------------------------------------------
 module Data.HodaTime.Calendar.Persian
 (

--- a/src/Data/HodaTime/CalendarDateTime/Internal.hs
+++ b/src/Data/HodaTime/CalendarDateTime/Internal.hs
@@ -107,11 +107,12 @@ class HasDate d where
   --
   --   This is purely an access optimization for code that needs more than one date component at once.  Reading the
   --   components individually with 'year', 'month' and 'day' is perfectly correct, but for a packed representation
-  --   (e.g. 'NCalendarDate') each of those accessors independently decodes the stored value, so asking for all three
-  --   separately decodes it three times.  'yearMonthDay' decodes once and hands back every component, which is
-  --   noticeably cheaper on hot paths (for example date formatting).  For representations that already store the
-  --   components separately (e.g. 'CalendarDate') there is nothing to decode and this is simply the three field reads,
-  --   so it is never slower than the individual accessors and callers can use it unconditionally.
+  --   (such as the Gregorian 'Date', which stores a cycle\/century\/day-in-century triple) each of those accessors
+  --   independently decodes the stored value, so asking for all three separately decodes it three times.
+  --   'yearMonthDay' decodes once and hands back every component, which is noticeably cheaper on hot paths (for
+  --   example date formatting).  For representations that already store the components separately (such as the Julian
+  --   'Date') there is nothing to decode and this is simply the three field reads, so it is never slower than the
+  --   individual accessors and callers can use it unconditionally.
   yearMonthDay :: d -> (Year, MoY d, DayOfMonth)
   yearMonthDay d = (getConst (year Const d), month d, getConst (day Const d))
 

--- a/src/Data/HodaTime/Pattern/ApplyParse.hs
+++ b/src/Data/HodaTime/Pattern/ApplyParse.hs
@@ -16,11 +16,8 @@ import Data.HodaTime.CalendarDateTime.Internal (IsCalendar(..), Date, CalendarDa
 import Data.HodaTime.Pattern.ParseTypes
 import Control.Monad.Catch (MonadThrow)
 
+defaultTime :: TimeInfo
 defaultTime = TimeInfo 0 0 0 0
-
-defaultDate = DateInfo Nothing Nothing Nothing
-
-defaultDateTime = DateTimeInfo defaultDate defaultTime
 
 -- Class
 
@@ -46,7 +43,7 @@ instance ApplyParse TimeInfo LocalTime where
       ti = f defaultTime
 
 instance IsCalendar cal => ApplyParse (DateInfo cal) (Date cal) where
-  applyParse f = undefined
+  applyParse _ = undefined
 
 {- class ApplyParse r where
   type StartData r

--- a/src/Data/HodaTime/Pattern/ZonedDateTime.hs
+++ b/src/Data/HodaTime/Pattern/ZonedDateTime.hs
@@ -29,13 +29,11 @@ import Data.HodaTime.Pattern.Internal
 import Data.HodaTime.CalendarDateTime.Internal (IsCalendar, Month)
 import Data.HodaTime.ZonedDateTime.Internal (ZonedDateTime(..))
 import qualified Data.HodaTime.ZonedDateTime.Internal as ZDT
-import Control.Monad.Catch (MonadThrow, throwM)
-import qualified  Data.Text as T
-import qualified  Data.Text.Lazy.Builder as TLB
+import Control.Monad.Catch (MonadThrow)
 import Control.Applicative ((<|>))
-import Text.Parsec (digit, count, string, choice, oneOf, (<?>))
+import Text.Parsec (digit, count, oneOf, (<?>))
 import qualified Text.Parsec as P (char)
-import Formatting (left, (%.), later)
+import Formatting (left, (%.))
 
 data ZonedDateTimeInfo cal m =
   ZonedDateTimeInfo

--- a/src/Data/HodaTime/TimeZone/Internal.hs
+++ b/src/Data/HodaTime/TimeZone/Internal.hs
@@ -28,7 +28,7 @@ import Data.Maybe (fromMaybe)
 import Data.HodaTime.Instant.Internal (Instant(..), minus, bigBang)
 import Data.HodaTime.Offset.Internal (Offset(..), adjustInstant)
 import Data.HodaTime.Duration.Internal (fromNanoseconds)
-import Data.HodaTime.Calendar.Gregorian.Internal (nthDayToDayOfMonth, yearMonthDayToDays, instantToYearMonthDay)
+import Data.HodaTime.Calendar.Gregorian.Internal (nthDayToDayOfMonth, yearMonthDayToDays, maxDaysInMonth, instantToYearMonthDay)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.IntervalMap.FingerTree (IntervalMap, Interval(..))
@@ -191,7 +191,14 @@ yearExpressionToInstant y = go
         m' = toEnum m
         d = nthDayToDayOfMonth nth day m' y
         days' = fromIntegral $ yearMonthDayToDays y m' d
-    -- TODO: implement the POSIX @Jn@/@n@ transition form.  NOTE: this "Julian" is a day-of-year (the @Jn@ form is
-    --       1..365 ignoring Feb 29, the @n@ form is 0..365 counting it), NOT the Julian *calendar* - it needs a
-    --       day-of-year -> Instant helper, unrelated to Data.HodaTime.Calendar.Julian.
-    go (JulianExpression _cly _d _s) = error "need julian year day function"
+    go (JulianExpression countLeaps day s) = Instant days' (fromIntegral s) 0
+      where
+        -- POSIX day-of-year transition.  The @n@ form (countLeaps == True) is 0-based and counts 29.Feb; the @Jn@
+        -- form (countLeaps == False) is 1-based and never counts 29.Feb, so 1.Mar is always day 60.  NOTE: this is a
+        -- day-of-year, unrelated to the Julian *calendar*.
+        offset
+          | countLeaps          = day
+          | isLeap && day >= 60  = day
+          | otherwise            = day - 1
+        isLeap = maxDaysInMonth (toEnum 1) y == 29
+        days' = fromIntegral $ yearMonthDayToDays y (toEnum 0) 1 + offset

--- a/src/Data/HodaTime/TimeZone/Internal.hs
+++ b/src/Data/HodaTime/TimeZone/Internal.hs
@@ -191,4 +191,7 @@ yearExpressionToInstant y = go
         m' = toEnum m
         d = nthDayToDayOfMonth nth day m' y
         days' = fromIntegral $ yearMonthDayToDays y m' d
+    -- TODO: implement the POSIX @Jn@/@n@ transition form.  NOTE: this "Julian" is a day-of-year (the @Jn@ form is
+    --       1..365 ignoring Feb 29, the @n@ form is 0..365 counting it), NOT the Julian *calendar* - it needs a
+    --       day-of-year -> Instant helper, unrelated to Data.HodaTime.Calendar.Julian.
     go (JulianExpression _cly _d _s) = error "need julian year day function"

--- a/tests/HodaTime/Calendar/GregorianTest.hs
+++ b/tests/HodaTime/Calendar/GregorianTest.hs
@@ -21,7 +21,7 @@ gregorianTests :: TestTree
 gregorianTests = testGroup "Gregorian Tests" [qcProps, unitTests]
 
 qcProps :: TestTree
-qcProps = testGroup "(checked by QuickCheck)" [constructorProps, lensProps]
+qcProps = testGroup "(checked by QuickCheck)" [constructorProps, lensProps, nthDayProps]
 
 unitTests :: TestTree
 unitTests = testGroup "Unit tests" [constructorUnits, lensUnits, boundaryUnits]
@@ -90,6 +90,23 @@ lensProps = testGroup "Lens"
     testDirectionRange dir gtlt adjust dow (RandomStandardDate y m d) = let cd = mkcd d m y in dir 1 dow cd `gtlt` modify (adjust 8) day cd
     epochDay = mkcd 1 March 2000
 
+nthDayProps :: TestTree
+nthDayProps = testGroup "fromNthDay / fromWeekDate"
+  [
+     QC.testProperty "fromNthDay First dow is the first such weekday (day 1..7)" testFirst
+    ,QC.testProperty "fromNthDay Last dow is the last such weekday (final week)" testLast
+    ,QC.testProperty "fromWeekDate lands on the requested day-of-week" testWeekDoW
+  ]
+  where
+    testFirst dow (RandomStandardDate y m _) =
+      let r = fromNthDay First dow m y
+      in (dayOfWeek <$> r) == Just dow && maybe False (\d -> get day d >= 1 && get day d <= 7) r
+    testLast dow (RandomStandardDate y m _) =
+      let r = fromNthDay Last dow m y
+      in (dayOfWeek <$> r) == Just dow && maybe False (\d -> get day d >= 22) r
+    testWeekDoW dow (RandomStandardDate y _ _) (Positive w) =
+      maybe True ((== dow) . dayOfWeek) (G.fromWeekDate (1 + w `mod` 50) dow y)
+
 constructorUnits :: TestTree
 constructorUnits = testGroup "Constructor"
   [
@@ -102,6 +119,9 @@ constructorUnits = testGroup "Constructor"
     ,testCase "Holidays in year 2000" $ test2k (usaHolidays 2000)
     ,testCase "Holidays in year 2001" $ test2001 (usaHolidays 2001)
     ,testCase "Holidays in year 1582" $ test1582 (usaHolidays 1582)
+    ,testCase "fromNthDay Last, when the month ends on that weekday, is the last day (not a week early)" $
+       let lastDay = fromJust $ calendarDate 31 December 2000    -- 31.Dec.2000 is a Sunday
+       in fromNthDay Last (dayOfWeek lastDay) December 2000 @?= Just lastDay
   ]
     where
       test2k hs = do

--- a/tests/HodaTime/Calendar/JulianTest.hs
+++ b/tests/HodaTime/Calendar/JulianTest.hs
@@ -11,14 +11,14 @@ import Data.Maybe (fromJust)
 import Data.Time.Calendar.Julian (fromJulianValid, toJulian)
 
 import HodaTime.Util
-import Data.HodaTime.CalendarDate (day, monthl, month, year, next, previous, dayOfWeek, CalendarDate)
-import Data.HodaTime.Calendar.Julian (calendarDate, Julian, Month(..), DayOfWeek(..))
+import Data.HodaTime.CalendarDate (day, monthl, month, year, next, previous, dayOfWeek, DayNth(..), CalendarDate)
+import Data.HodaTime.Calendar.Julian (calendarDate, fromNthDay, fromWeekDate, Julian, Month(..), DayOfWeek(..))
 
 julianTests :: TestTree
 julianTests = testGroup "Julian Tests" [qcProps, unitTests]
 
 qcProps :: TestTree
-qcProps = testGroup "(checked by QuickCheck)" [constructorProps, lensProps]
+qcProps = testGroup "(checked by QuickCheck)" [constructorProps, lensProps, nthDayProps]
 
 unitTests :: TestTree
 unitTests = testGroup "Unit tests" [constructorUnits, lensUnits]
@@ -61,6 +61,25 @@ lensProps = testGroup "Lens"
     testDirection dir adjust (Positive n) = dir n (dayOfWeek epochDay) epochDay == modify (adjust $ n * 7) day epochDay
     testRoundTrip (RandomJulianDate y m d) = (ymd <$> calendarDate d m y) == Just (d, succ (fromEnum m), y)
 
+-- | 'fromNthDay' and 'fromWeekDate' are the generic (calendar-agnostic) constructors instantiated for Julian.  These
+--   self-validating properties confirm the shared core works with Julian's own weekday math (no per-calendar formula).
+nthDayProps :: TestTree
+nthDayProps = testGroup "fromNthDay / fromWeekDate"
+  [
+     QC.testProperty "fromNthDay First dow is the first such weekday (day 1..7)" testFirst
+    ,QC.testProperty "fromNthDay Last dow is the last such weekday (final week)" testLast
+    ,QC.testProperty "fromWeekDate lands on the requested day-of-week" testWeekDoW
+  ]
+  where
+    testFirst dow (RandomJulianDate y m _) =
+      let r = fromNthDay First dow m y
+      in (dayOfWeek <$> r) == Just dow && maybe False (\d -> get day d >= 1 && get day d <= 7) r
+    testLast dow (RandomJulianDate y m _) =
+      let r = fromNthDay Last dow m y
+      in (dayOfWeek <$> r) == Just dow && maybe False (\d -> get day d >= 22) r
+    testWeekDoW dow (RandomJulianDate y _ _) =
+      maybe True ((== dow) . dayOfWeek) (fromWeekDate 1 dow y)
+
 constructorUnits :: TestTree
 constructorUnits = testGroup "Constructor"
   [
@@ -69,6 +88,9 @@ constructorUnits = testGroup "Constructor"
     ,testCase "29 February 1900 matches Data.Time" $ (ymd <$> calendarDate 29 February 1900) @?= (juYmd <$> fromJulianValid 1900 2 29)
     ,testCase "14 October 1066 is valid (long before the 1582 Gregorian cutoff)" $ (ymd <$> calendarDate 14 October 1066) @?= Just (14, 10, 1066)
     ,testCase "14 October 1066 matches Data.Time" $ (ymd <$> calendarDate 14 October 1066) @?= (juYmd <$> fromJulianValid 1066 10 14)
+    ,testCase "fromNthDay Last, when the month ends on that weekday, is the last day (not a week early)" $
+       let lastDay = fromJust $ calendarDate 28 February 301    -- Feb 301 (not a Julian leap year) ends on a Friday
+       in fromNthDay Last (dayOfWeek lastDay) February 301 @?= Just lastDay
   ]
     where
       juYmd d = let (ty, tm, td) = toJulian d in (td, tm, fromIntegral ty)

--- a/tests/HodaTime/Calendar/JulianTest.hs
+++ b/tests/HodaTime/Calendar/JulianTest.hs
@@ -45,7 +45,7 @@ constructorProps = testGroup "Constructor"
       convertMonth = succ . fromEnum
       testConstructor (Positive y) m (Positive d) = areSame (calendarDate d m y') (fromJulianValid (fromIntegral y') (convertMonth m) d)
         where
-          y' = 1583 + (y `mod` 800)
+          y' = 1 + (y `mod` 2400)     -- NOTE: spans early-medieval (pre-1582) through modern years
 
 lensProps :: TestTree
 lensProps = testGroup "Lens"
@@ -67,6 +67,8 @@ constructorUnits = testGroup "Constructor"
      testCase "30 February 2000 is not a valid date" $ calendarDate 30 February 2000 @?= Nothing
     ,testCase "29 February 1900 IS valid in Julian (1900 is a Julian leap year)" $ (ymd <$> calendarDate 29 February 1900) @?= Just (29, 2, 1900)
     ,testCase "29 February 1900 matches Data.Time" $ (ymd <$> calendarDate 29 February 1900) @?= (juYmd <$> fromJulianValid 1900 2 29)
+    ,testCase "14 October 1066 is valid (long before the 1582 Gregorian cutoff)" $ (ymd <$> calendarDate 14 October 1066) @?= Just (14, 10, 1066)
+    ,testCase "14 October 1066 matches Data.Time" $ (ymd <$> calendarDate 14 October 1066) @?= (juYmd <$> fromJulianValid 1066 10 14)
   ]
     where
       juYmd d = let (ty, tm, td) = toJulian d in (td, tm, fromIntegral ty)

--- a/tests/HodaTime/Calendar/JulianTest.hs
+++ b/tests/HodaTime/Calendar/JulianTest.hs
@@ -1,0 +1,80 @@
+module HodaTime.Calendar.JulianTest
+(
+  julianTests
+)
+where
+
+import Test.Tasty
+import Test.Tasty.QuickCheck as QC
+import Test.Tasty.HUnit
+import Data.Maybe (fromJust)
+import Data.Time.Calendar.Julian (fromJulianValid, toJulian)
+
+import HodaTime.Util
+import Data.HodaTime.CalendarDate (day, monthl, month, year, next, previous, dayOfWeek, CalendarDate)
+import Data.HodaTime.Calendar.Julian (calendarDate, Julian, Month(..), DayOfWeek(..))
+
+julianTests :: TestTree
+julianTests = testGroup "Julian Tests" [qcProps, unitTests]
+
+qcProps :: TestTree
+qcProps = testGroup "(checked by QuickCheck)" [constructorProps, lensProps]
+
+unitTests :: TestTree
+unitTests = testGroup "Unit tests" [constructorUnits, lensUnits]
+
+-- | Decode a Julian date to (day, 1-based month, year) for explicit expected-value assertions.
+ymd :: CalendarDate Julian -> (Int, Int, Int)
+ymd x = (get day x, succ . fromEnum $ month x, get year x)
+
+-- | Differential test: 'Data.Time.Calendar.Julian' is the proleptic-Julian oracle.  This is the same shape as the
+--   Gregorian constructor property, but it exercises Julian's simpler every-4-years leap rule (so e.g. 1900 is a
+--   leap year here, unlike in the Gregorian calendar).
+constructorProps :: TestTree
+constructorProps = testGroup "Constructor"
+  [
+    QC.testProperty "same dates as Data.Time" $ testConstructor
+  ]
+    where
+      areSame Nothing Nothing = True
+      areSame (Just hdate) (Just date) =
+        let
+          (ty, tm, tday) = toJulian date
+        in get day hdate == tday && (convertMonth . month $ hdate) == tm && get year hdate == fromIntegral ty
+      areSame _ _ = False
+      convertMonth = succ . fromEnum
+      testConstructor (Positive y) m (Positive d) = areSame (calendarDate d m y') (fromJulianValid (fromIntegral y') (convertMonth m) d)
+        where
+          y' = 1583 + (y `mod` 800)
+
+lensProps :: TestTree
+lensProps = testGroup "Lens"
+  [
+     QC.testProperty "dayOfWeek . next n dow $ date == dow" $ testNextDoW
+    ,QC.testProperty "next n (dayOfWeek date) date == modify (+ n * 7) day date" $ testDirection next (+)
+    ,QC.testProperty "previous n (dayOfWeek date) date == modify (- n * 7) day date" $ testDirection previous $ flip (-)
+    ,QC.testProperty "construct -> decode round-trips" $ testRoundTrip
+  ]
+  where
+    epochDay = fromJust $ calendarDate 1 March 2000
+    testNextDoW dow (Positive n) = (dayOfWeek . next n dow $ epochDay) == dow
+    testDirection dir adjust (Positive n) = dir n (dayOfWeek epochDay) epochDay == modify (adjust $ n * 7) day epochDay
+    testRoundTrip (RandomJulianDate y m d) = (ymd <$> calendarDate d m y) == Just (d, succ (fromEnum m), y)
+
+constructorUnits :: TestTree
+constructorUnits = testGroup "Constructor"
+  [
+     testCase "30 February 2000 is not a valid date" $ calendarDate 30 February 2000 @?= Nothing
+    ,testCase "29 February 1900 IS valid in Julian (1900 is a Julian leap year)" $ (ymd <$> calendarDate 29 February 1900) @?= Just (29, 2, 1900)
+    ,testCase "29 February 1900 matches Data.Time" $ (ymd <$> calendarDate 29 February 1900) @?= (juYmd <$> fromJulianValid 1900 2 29)
+  ]
+    where
+      juYmd d = let (ty, tm, td) = toJulian d in (td, tm, fromIntegral ty)
+
+lensUnits :: TestTree
+lensUnits = testGroup "Lens"
+  [
+     testCase "31 January 2000 + 1M == 29 February 2000 (2000 is a Julian leap year)" $ (ymd <$> (modify (+1) monthl <$> calendarDate 31 January 2000)) @?= Just (29, 2, 2000)
+    ,testCase "31 December 2000 + 1D == 1 January 2001" $ (ymd <$> (modify (+1) day <$> calendarDate 31 December 2000)) @?= Just (1, 1, 2001)
+    ,testCase "29 February 1900 + 1Y clamps to 28 February 1901" $ (ymd <$> (modify (+1) year <$> calendarDate 29 February 1900)) @?= Just (28, 2, 1901)
+  ]

--- a/tests/HodaTime/InstantTest.hs
+++ b/tests/HodaTime/InstantTest.hs
@@ -11,9 +11,11 @@ import Data.HodaTime.Instant (fromSecondsSinceUnixEpoch)
 import Data.HodaTime.TimeZone (utc, timeZone)
 import Data.HodaTime.ZonedDateTime (fromInstant, toLocalTime, toInstant, ZonedDateTime, year, month, day)
 import Data.HodaTime.Calendar.Gregorian (Gregorian)
+import Data.HodaTime.Calendar.Julian (Julian)
 import Data.HodaTime.LocalTime (HasLocalTime(..))
 import Data.Time.Clock.POSIX (getPOSIXTime, posixSecondsToUTCTime)
 import Data.Time.Calendar (toGregorian)
+import Data.Time.Calendar.Julian (toJulian)
 import Data.Time.LocalTime (todHour, todMin, todSec, hoursToTimeZone, utcToLocalTime, LocalTime(..))
 import qualified System.Info as SysInfo
 import HodaTime.Util (get)
@@ -27,6 +29,7 @@ unitTests = testGroup "Unit tests"
      testCase "test_fromSecondsSinceUnixEpoch" test_fromSecondsSinceUnixEpoch
     ,testCase "test_instantDate" test_instantDate
     ,testCase "test_instantRoundTrip" test_instantRoundTrip
+    ,testCase "test_instantCrossCalendar" test_instantCrossCalendar
   ]
 
 test_fromSecondsSinceUnixEpoch :: Assertion
@@ -78,3 +81,27 @@ test_instantRoundTrip = mapM_ check ["UTC", euZone]
         zdt :: ZonedDateTime Gregorian
         zdt = fromInstant inst tz
       assertEqual ("Instant -> ZonedDateTime -> Instant round-trips in " ++ zoneName) inst (toInstant zdt)
+
+-- | The SAME 'Instant' decoded into two different calendars must land on the same absolute day: its Gregorian and
+--   Julian labels must each match Data.Time, and both 'ZonedDateTime's must convert back (via 'toInstant') to the
+--   original 'Instant'.  This locks in the Julian epoch alignment \- Julian must be 13 days behind Gregorian in the
+--   modern era, not identical to it.
+test_instantCrossCalendar :: Assertion
+test_instantCrossCalendar = do
+  tz <- utc
+  let
+    inst = fromSecondsSinceUnixEpoch 1592352000     -- 2020-06-17T00:00:00Z
+    zdtG :: ZonedDateTime Gregorian
+    zdtG = fromInstant inst tz
+    zdtJ :: ZonedDateTime Julian
+    zdtJ = fromInstant inst tz
+    utcT = posixSecondsToUTCTime 1592352000
+    (LocalTime dayGreg _) = utcToLocalTime (hoursToTimeZone 0) utcT
+    (gy, gm, gd) = toGregorian dayGreg
+    (jy, jm, jd) = toJulian dayGreg
+    actualG = (year zdtG, succ . fromEnum $ month zdtG, day zdtG)
+    actualJ = (year zdtJ, succ . fromEnum $ month zdtJ, day zdtJ)
+  assertEqual "Gregorian date" (fromIntegral gy, gm, gd) actualG
+  assertEqual "Julian date (13 days behind Gregorian in 2020)" (fromIntegral jy, jm, jd) actualJ
+  assertEqual "Gregorian round-trips to the same Instant" inst (toInstant zdtG)
+  assertEqual "Julian round-trips to the same Instant" inst (toInstant zdtJ)

--- a/tests/HodaTime/Util.hs
+++ b/tests/HodaTime/Util.hs
@@ -5,6 +5,7 @@ module HodaTime.Util
   ,RandomTime(..)
   ,CycleYear(..)
   ,RandomStandardDate(..)
+  ,RandomJulianDate(..)
   ,get
   ,modify
   ,set
@@ -17,6 +18,7 @@ import Control.Applicative (Const(..))
 import Data.Functor.Identity (Identity(..))
 
 import Data.HodaTime.Calendar.Gregorian (Month(..), DayOfWeek(..), Gregorian)
+import qualified Data.HodaTime.Calendar.Julian as J
 
 -- arbitrary data and instances
 
@@ -74,6 +76,28 @@ instance Arbitrary RandomStandardDate where
     m <- choose (0,11)
     d <- choose (1,28)
     return $ RandomStandardDate y (toEnum m) d
+
+instance Arbitrary (J.Month J.Julian) where
+  arbitrary = do
+    x <- choose (0,11)
+    return $ toEnum x
+
+instance Arbitrary (J.DayOfWeek J.Julian) where
+  arbitrary = do
+    x <- choose (0,6)
+    return $ toEnum x
+
+-- | A random valid Julian date.  The range starts in 1583 to stay clear of the pre-1582 validity threshold, and
+--   the day is capped at 28 so every generated (year, month, day) is a real date.
+data RandomJulianDate = RandomJulianDate Int (J.Month J.Julian) Int
+  deriving (Show)
+
+instance Arbitrary RandomJulianDate where
+  arbitrary = do
+    y <- choose (1583,2400)
+    m <- choose (0,11)
+    d <- choose (1,28)
+    return $ RandomJulianDate y (toEnum m) d
 
 -- Lenses
 

--- a/tests/HodaTime/Util.hs
+++ b/tests/HodaTime/Util.hs
@@ -87,14 +87,15 @@ instance Arbitrary (J.DayOfWeek J.Julian) where
     x <- choose (0,6)
     return $ toEnum x
 
--- | A random valid Julian date.  The range starts in 1583 to stay clear of the pre-1582 validity threshold, and
---   the day is capped at 28 so every generated (year, month, day) is a real date.
+-- | A random valid Julian date.  Unlike Gregorian (which rejects pre\-1582 dates), the Julian calendar is valid for
+--   all AD years, so the range spans early\-medieval through modern years to exercise the pre\-1582 dates the calendar
+--   exists to represent.  The day is capped at 28 so every generated (year, month, day) is a real date.
 data RandomJulianDate = RandomJulianDate Int (J.Month J.Julian) Int
   deriving (Show)
 
 instance Arbitrary RandomJulianDate where
   arbitrary = do
-    y <- choose (1583,2400)
+    y <- choose (1,2400)
     m <- choose (0,11)
     d <- choose (1,28)
     return $ RandomJulianDate y (toEnum m) d

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -5,6 +5,7 @@ import HodaTime.DurationTest
 import HodaTime.OffsetTest
 import HodaTime.LocalTimeTest
 import HodaTime.Calendar.GregorianTest
+import HodaTime.Calendar.JulianTest
 import HodaTime.CalendarDateTimeTest
 import HodaTime.ZonedDateTimeTest
 import HodaTime.PatternTest
@@ -13,7 +14,7 @@ main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "Tests" [instantTests, durationTests, offsetTests, localTimeTests, gregorianTests, calendarDateTimeTests, zonedDateTimeTests, patternTests]
+tests = testGroup "Tests" [instantTests, durationTests, offsetTests, localTimeTests, gregorianTests, julianTests, calendarDateTimeTests, zonedDateTimeTests, patternTests]
 
 {-
 unitTests :: TestTree


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the calendar modules, most notably extracting and generalizing logic for constructing dates from "nth weekday" and "week date" rules. It also adds missing constructors for the Julian calendar and enhances documentation across multiple calendar modules. The changes improve code reuse, maintainability, and clarity.

### Calendar construction generalization

* Introduced generic calendar-agnostic functions `mkFromNthDay` and `mkFromWeekDate` in `Data.HodaTime.Calendar.Internal`, and refactored Gregorian and Julian calendar modules to use these for their `fromNthDay` and `fromWeekDate` constructors. This centralizes and simplifies the logic for these operations. [[1]](diffhunk://#diff-8eadc63bba1bb1b472f01157101f3eb46b5d46eb0b270399256764b36596acb9R8-R9) [[2]](diffhunk://#diff-8eadc63bba1bb1b472f01157101f3eb46b5d46eb0b270399256764b36596acb9R101-R154) [[3]](diffhunk://#diff-5dc1969244a9842297bf568bf0126a5d2b7db6a3b4c945a627eb53e212528222R32-R52) [[4]](diffhunk://#diff-f5a8c295941a4c8004b3b4c06793db9786dd02737fae38a4ec7fd31712d271c5L27-L33) [[5]](diffhunk://#diff-f5a8c295941a4c8004b3b4c06793db9786dd02737fae38a4ec7fd31712d271c5L106-L129) [[6]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22R121-R139) [[7]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22L11-R69)

* Added the `fromNthDay` and `fromWeekDate` smart constructors to the Julian calendar, making it consistent with the Gregorian calendar and enabling week-based and nth-day date construction for Julian dates. [[1]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22L11-R69) [[2]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22R121-R139) [[3]](diffhunk://#diff-34273afbd85940057361cf5f2bc34c0f9ef907c3d658751ba6bd3a77212e7e03R127)

### Documentation improvements

* Expanded and clarified module-level documentation for the Coptic, Hebrew, Islamic, Gregorian, Julian, and ISO calendar modules, providing more historical context, implementation notes, and details on leap year rules and calendar cutoffs. [[1]](diffhunk://#diff-34922540880e9501b5da15a6c1e67a8cef24572ca34cfbe5fac621a5eaa44238L10-R13) [[2]](diffhunk://#diff-4660af517905ba1469269e5d5113a323302ec4fa7c0caae67795010813fb2615L10-R13) [[3]](diffhunk://#diff-5872592f7b83ab876337e8dd3bfbf4fab4a8481065a564d63d481d273ae7bb97L10-R14) [[4]](diffhunk://#diff-5dc1969244a9842297bf568bf0126a5d2b7db6a3b4c945a627eb53e212528222L10-R15) [[5]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22L11-R69) [[6]](diffhunk://#diff-9619403867c824448fc7bf9cfd5b4e7d61deff349745315bdea2ffac25e79f09L10-R13)

### Test suite update

* Added `HodaTime.Calendar.JulianTest` to the test suite to ensure coverage of the Julian calendar's new and existing functionality.

### Minor code improvements

* Improved the implementation of `nthDayToDayOfMonth` in Gregorian internals to handle "from last" week logic more accurately and robustly.

* Cleaned up imports, removed unused code, and improved comments for clarity and maintainability across several modules. [[1]](diffhunk://#diff-8eadc63bba1bb1b472f01157101f3eb46b5d46eb0b270399256764b36596acb9L18-R24) [[2]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22L11-R69)

These changes collectively make the calendar modules more robust, easier to extend, and more consistent in their APIs and documentation.