### PR TITLE
Epoch fixes

### DIFF
--- a/src/Data/HodaTime/Calendar/Coptic.hs
+++ b/src/Data/HodaTime/Calendar/Coptic.hs
@@ -45,7 +45,9 @@ daysPerMonth = 30
 daysBeforeEpagomenae :: Int
 daysBeforeEpagomenae = 12 * daysPerMonth      -- 360
 
--- | Flat day (shared absolute epoch, day 0 = 1.Mar.2000 Gregorian) of Coptic 1.Thout.1, i.e. 29.Aug.284 Julian.
+-- | Coptic works in its own frame: internal flat day 0 is 1.Thout.1 (= 29.Aug.284 Julian).  Only the 'Instant' bridge
+--   crosses to the universal timeline (day 0 = 1.Mar.2000 Gregorian), where the Coptic epoch sits at this constant, so
+--   'toUnadjustedInstant' adds it and 'fromAdjustedInstant' subtracts it.
 copticEpoch :: Num a => a
 copticEpoch = -626575
 
@@ -59,7 +61,7 @@ invalidDayThresh = fromIntegral $ pred day0
     day0 = yearMonthDayToDays y (toEnum m) d
 
 epochDayOfWeek :: DayOfWeek Coptic
-epochDayOfWeek = Wednesday
+epochDayOfWeek = Friday
 
 -- types
 
@@ -97,8 +99,8 @@ instance IsCalendar Coptic where
   previous' n dow (CopticDate days _ _ _) = moveByDow copticFromDays epochDayOfWeek n dow subtract (-) (<) (fromIntegral days)  -- NOTE: subtract is (-) with the arguments flipped
 
 instance IsCalendarDateTime Coptic where
-  fromAdjustedInstant (Instant days secs nsecs) = CalendarDateTime (copticFromDays days) (LocalTime secs nsecs)
-  toUnadjustedInstant (CalendarDateTime cd (LocalTime secs nsecs)) = Instant (copticToDays cd) secs nsecs
+  fromAdjustedInstant (Instant days secs nsecs) = CalendarDateTime (copticFromDays (days - copticEpoch)) (LocalTime secs nsecs)
+  toUnadjustedInstant (CalendarDateTime cd (LocalTime secs nsecs)) = Instant (copticToDays cd + copticEpoch) secs nsecs
 
 -- | Build the flat Coptic date (denormalized: keeps the day count plus the decoded day\/month\/year).
 copticFromDays :: Int32 -> Date Coptic
@@ -141,12 +143,12 @@ maxDaysInMonth PiKogiEnavot y
 maxDaysInMonth _ _                         = daysPerMonth
 
 yearMonthDayToDays :: Year -> Month Coptic -> DayOfMonth -> Int
-yearMonthDayToDays y m d = copticEpoch + (y - 1) * daysPerStandardYear + y `div` 4 + fromEnum m * daysPerMonth + d - 1
+yearMonthDayToDays y m d = (y - 1) * daysPerStandardYear + y `div` 4 + fromEnum m * daysPerMonth + d - 1
 
 daysToYearMonthDay :: Int32 -> (Int32, Word8, Word8)
 daysToYearMonthDay flatDays = (fromIntegral y, fromIntegral m, fromIntegral d)
   where
-    n = fromIntegral flatDays - copticEpoch                          -- days since 1.Thout.1 (>= 0 for valid dates)
+    n = fromIntegral flatDays                                        -- days since 1.Thout.1 (>= 0 for valid dates)
     (fourYears, remaining) = n `divMod` daysPerFourYears             -- 1461-day cycle, leap year last in each block
     (yearInBlock, dayOfYear)
       | remaining < 365       = (0, remaining)

--- a/src/Data/HodaTime/Calendar/Julian.hs
+++ b/src/Data/HodaTime/Calendar/Julian.hs
@@ -8,11 +8,23 @@
 -- Stability   :  experimental
 -- Portability :  POSIX, Windows
 --
--- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Julian' calendar.  The Julian calendar has a simple leap year rule \- every fourth year is a leap year, with none of the
--- century exceptions that 'Data.HodaTime.Calendar.Gregorian' later added to keep the calendar aligned to the solar year.  It is fully proleptic: it applies that rule uniformly to every year, forward
--- and backward (it does not try to account for the fact that before around 4 AD the leap year rule was accidentally implemented as a leap year every three years).  Years use astronomical numbering, so
--- year 1 is AD 1, year 0 is 1 BC, year -1 is 2 BC and so on.  Dates share the same absolute timeline as every other calendar, so in the modern era a Julian date reads 13 days behind the same instant's
--- Gregorian date.
+-- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Julian' calendar.  The Julian calendar has a simple leap year rule \- every fourth year is a leap year, with none of the century
+-- exceptions that 'Data.HodaTime.Calendar.Gregorian' later added to keep the calendar aligned to the solar year.  Years use astronomical numbering, so year 1 is AD 1, year 0 is 1 BC, year -1 is 2 BC
+-- and so on; dates run from the calendar's introduction on 1.January.45 BC (year -44) onward, with no upper bound.  Dates share the same absolute timeline as every other calendar, so in the modern era
+-- a Julian date reads 13 days behind the same instant's Gregorian date.  The Julian calendar is not merely historical \- the Eastern Orthodox churches still use it liturgically, so it stays useful for
+-- both past dates and current and future feast-day calculations.
+--
+-- == Proleptic every-fourth-year rule
+--
+-- This implementation applies the clean every-fourth-year rule uniformly from 45 BC onward.  It deliberately does /not/ reproduce the calendar's messy early history, in which the priests who
+-- administered it inserted a leap day every three years by mistake (the "triennial error") until Augustus suspended leap years to realign it, the regular rule only settling in by around AD 8.  We omit
+-- that for two reasons:
+--
+-- * The exact sequence of long years during 45 BC \- AD 7 is genuinely disputed: Scaliger, Ideler and Bennett each reconstruct it differently, so an "accurate" version would just bake one contested
+--   interpretation in as fact.
+--
+-- * By long-standing convention historians and astronomers already cite ancient dates in the /proleptic/ Julian calendar (the clean rule), precisely because the real sequence is uncertain.  For example
+--   "15.March.44 BC" for Caesar's assassination is a proleptic Julian date; modelling the errors would make this library disagree with the way such dates are normally written.
 ----------------------------------------------------------------------------
 module Data.HodaTime.Calendar.Julian
 (
@@ -39,15 +51,18 @@ import Data.List (findIndex)
 
 -- constants
 
--- | Julian uses astronomical year numbering (year 1 = AD 1, year 0 = 1 BC, year -1 = 2 BC, ...) and is fully proleptic
---   \- the every-fourth-year rule is applied forward and backward with no calendar cutoff.  There is therefore no real
---   "first valid date"; these sentinels sit at the bottom of the 'Int32' day representation (the only actual bound) so
---   the shared lens\/constructor helpers never clamp a Julian result.
+-- | Julian dates are valid from the calendar's introduction, 1.January.45 BC (astronomical year -44), onward; earlier
+--   dates are rejected \- the calendar did not exist and this implementation does not extend it backwards.  There is no
+--   upper bound beyond the 'Int32' day representation.  This tuple is also the floor the shared lens\/constructor
+--   helpers clamp to.
 firstJulDayTuple :: (Integral a, Integral b, Integral c) => (a, b, c)
-firstJulDayTuple = (fromIntegral (minBound :: Int32), 0, 1)
+firstJulDayTuple = (-44, 0, 1)        -- NOTE: 1.Jan.45 BC
 
 invalidDayThresh :: Integral a => a
-invalidDayThresh = fromIntegral (minBound :: Int32)
+invalidDayThresh = fromIntegral $ pred day0
+  where
+    (y, m, d) = firstJulDayTuple :: (Year, Int, DayOfMonth)
+    day0 = yearMonthDayToDays y (toEnum m) d
 
 epochDayOfWeek :: DayOfWeek Julian
 epochDayOfWeek = Tuesday

--- a/src/Data/HodaTime/Calendar/Julian.hs
+++ b/src/Data/HodaTime/Calendar/Julian.hs
@@ -53,16 +53,14 @@ invalidDayThresh = fromIntegral $ pred day0
     day0 = yearMonthDayToDays y (toEnum m) d
 
 epochDayOfWeek :: DayOfWeek Julian
-epochDayOfWeek = Wednesday
+epochDayOfWeek = Tuesday
 
--- | The Julian and (proleptic) Gregorian calendars diverge, so they cannot share a flat day 0 that is a clean date in
---   both.  'Data.HodaTime.Calendar.Gregorian' owns the shared absolute epoch (flat day 0 = 1.Mar.2000 Gregorian), which
---   the Julian calendar labels 17.Feb.2000.  Julian's own clean epoch (1.Mar.2000 Julian) sits 13 days later on that
---   shared timeline, so we shift the internal Julian day count by this constant to place it on the same absolute
---   timeline as every other calendar.  Because it is the gap between two fixed absolute days, the shift is constant for
---   all of time.
-julianEpochShift :: Num a => a
-julianEpochShift = 13
+-- | Julian works in its own frame: internal flat day 0 is 1.Mar.2000 in the Julian calendar.  Only the 'Instant'
+--   bridge crosses to the universal timeline (day 0 = 1.Mar.2000 Gregorian), where Julian's epoch sits 13 days later
+--   (the Julian\/Gregorian divergence), so 'toUnadjustedInstant' adds this offset and 'fromAdjustedInstant' subtracts
+--   it.  Because it is the gap between two fixed absolute days, the offset is constant for all of time.
+julianEpochOffset :: Num a => a
+julianEpochOffset = 13
 
 -- In case we ever decide to generate a 28 year table to store cycles
 -- daysPerSolarCycle :: Num a => a
@@ -104,8 +102,8 @@ instance IsCalendar Julian where
   previous' n dow (JulianDate days _ _ _) = moveByDow julianFromDays epochDayOfWeek n dow subtract (-) (<) (fromIntegral days)  -- NOTE: subtract is (-) with the arguments flipped
 
 instance IsCalendarDateTime Julian where
-  fromAdjustedInstant (Instant days secs nsecs) = CalendarDateTime (julianFromDays days) (LocalTime secs nsecs)
-  toUnadjustedInstant (CalendarDateTime jd (LocalTime secs nsecs)) = Instant (julianToDays jd) secs nsecs
+  fromAdjustedInstant (Instant days secs nsecs) = CalendarDateTime (julianFromDays (days - julianEpochOffset)) (LocalTime secs nsecs)
+  toUnadjustedInstant (CalendarDateTime jd (LocalTime secs nsecs)) = Instant (julianToDays jd + julianEpochOffset) secs nsecs
 
 -- | Build the flat Julian date (denormalized: keeps the day count plus the decoded day\/month\/year).
 julianFromDays :: Int32 -> Date Julian
@@ -155,12 +153,11 @@ yearMonthDayToDays y m d = days
     m' = if m > February then fromEnum m - 2 else fromEnum m + 10
     years = if m < March then y - 2001 else y - 2000
     yearDays = years * daysPerStandardYear + years `div` 4
-    days = yearDays + commonMonthDayOffsets !! m' + d - 1 + julianEpochShift
+    days = yearDays + commonMonthDayOffsets !! m' + d - 1
 
 daysToYearMonthDay :: Int32 -> (Int32, Word8, Word8)
-daysToYearMonthDay days0 = (fromIntegral y, fromIntegral m'', fromIntegral d')
+daysToYearMonthDay days = (fromIntegral y, fromIntegral m'', fromIntegral d')
   where
-    days = days0 - julianEpochShift
     (fourYears, (remaining, isLeapDay)) = flip divMod daysPerFourYears >>> (* 4) *** id &&& borders daysPerFourYears $ days
     (oneYears, yearDays) = remaining `divMod` daysPerStandardYear
     -- NOTE: the sentinel 'daysPerStandardYear' lets February (yearDays >= the last real offset) be found; without it

--- a/src/Data/HodaTime/Calendar/Julian.hs
+++ b/src/Data/HodaTime/Calendar/Julian.hs
@@ -9,10 +9,10 @@
 -- Portability :  POSIX, Windows
 --
 -- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Julian' calendar.  The Julian calendar has a simple leap year rule \- every fourth year is a leap year, with none of the
--- century exceptions that 'Data.HodaTime.Calendar.Gregorian' later added to keep the calendar aligned to the solar year.  It is proleptic in that, while it only started in 45 BC, this
--- implementation applies that rule uniformly and does not try to account for the fact that before around 4 AD the leap year rule was accidentally implemented as a leap year every three years.  This
--- implementation stores the year unsigned, so its supported range is AD 1 onward (BC years are not representable).  Dates share the same absolute timeline as every other calendar, so in the modern
--- era a Julian date reads 13 days behind the same instant's Gregorian date.
+-- century exceptions that 'Data.HodaTime.Calendar.Gregorian' later added to keep the calendar aligned to the solar year.  It is fully proleptic: it applies that rule uniformly to every year, forward
+-- and backward (it does not try to account for the fact that before around 4 AD the leap year rule was accidentally implemented as a leap year every three years).  Years use astronomical numbering, so
+-- year 1 is AD 1, year 0 is 1 BC, year -1 is 2 BC and so on.  Dates share the same absolute timeline as every other calendar, so in the modern era a Julian date reads 13 days behind the same instant's
+-- Gregorian date.
 ----------------------------------------------------------------------------
 module Data.HodaTime.Calendar.Julian
 (
@@ -39,18 +39,15 @@ import Data.List (findIndex)
 
 -- constants
 
--- | The Julian calendar predates the Gregorian one, so \- unlike 'Data.HodaTime.Calendar.Gregorian', which is only
---   valid from 15.Oct.1582 \- there is no reason to reject earlier dates here: rejecting pre\-1582 dates is exactly
---   what the Julian calendar exists to represent.  We floor at 1.Jan.AD 1 because the decoded year is stored unsigned
---   ('toYmd' returns a 'Word32' year), so BC years are not representable in this implementation.
+-- | Julian uses astronomical year numbering (year 1 = AD 1, year 0 = 1 BC, year -1 = 2 BC, ...) and is fully proleptic
+--   \- the every-fourth-year rule is applied forward and backward with no calendar cutoff.  There is therefore no real
+--   "first valid date"; these sentinels sit at the bottom of the 'Int32' day representation (the only actual bound) so
+--   the shared lens\/constructor helpers never clamp a Julian result.
 firstJulDayTuple :: (Integral a, Integral b, Integral c) => (a, b, c)
-firstJulDayTuple = (1, 0, 1)        -- NOTE: 1.Jan.AD 1
+firstJulDayTuple = (fromIntegral (minBound :: Int32), 0, 1)
 
 invalidDayThresh :: Integral a => a
-invalidDayThresh = fromIntegral $ pred day0
-  where
-    (y, m, d) = firstJulDayTuple :: (Year, Int, DayOfMonth)
-    day0 = yearMonthDayToDays y (toEnum m) d
+invalidDayThresh = fromIntegral (minBound :: Int32)
 
 epochDayOfWeek :: DayOfWeek Julian
 epochDayOfWeek = Tuesday

--- a/tests/HodaTime/Calendar/JulianTest.hs
+++ b/tests/HodaTime/Calendar/JulianTest.hs
@@ -43,9 +43,9 @@ constructorProps = testGroup "Constructor"
         in get day hdate == tday && (convertMonth . month $ hdate) == tm && get year hdate == fromIntegral ty
       areSame _ _ = False
       convertMonth = succ . fromEnum
-      testConstructor (Positive y) m (Positive d) = areSame (calendarDate d m y') (fromJulianValid (fromIntegral y') (convertMonth m) d)
+      testConstructor y m (Positive d) = areSame (calendarDate d m y') (fromJulianValid (fromIntegral y') (convertMonth m) d)
         where
-          y' = 1 + (y `mod` 2400)     -- NOTE: spans early-medieval (pre-1582) through modern years
+          y' = (y `mod` 4801) - 2400     -- NOTE: spans 2400 BC .. AD 2400 (astronomical numbering, year 0 = 1 BC)
 
 lensProps :: TestTree
 lensProps = testGroup "Lens"
@@ -91,6 +91,10 @@ constructorUnits = testGroup "Constructor"
     ,testCase "fromNthDay Last, when the month ends on that weekday, is the last day (not a week early)" $
        let lastDay = fromJust $ calendarDate 28 February 301    -- Feb 301 (not a Julian leap year) ends on a Friday
        in fromNthDay Last (dayOfWeek lastDay) February 301 @?= Just lastDay
+    ,testCase "1 BC (year 0) is a Julian leap year: 29 February is valid" $ (ymd <$> calendarDate 29 February 0) @?= Just (29, 2, 0)
+    ,testCase "1 BC (year 0) 29 February matches Data.Time" $ (ymd <$> calendarDate 29 February 0) @?= (juYmd <$> fromJulianValid 0 2 29)
+    ,testCase "2 BC (year -1) is not a leap year: 29 February is invalid" $ calendarDate 29 February (-1) @?= Nothing
+    ,testCase "45 BC (year -44) 1 January matches Data.Time" $ (ymd <$> calendarDate 1 January (-44)) @?= (juYmd <$> fromJulianValid (-44) 1 1)
   ]
     where
       juYmd d = let (ty, tm, td) = toJulian d in (td, tm, fromIntegral ty)

--- a/tests/HodaTime/Calendar/JulianTest.hs
+++ b/tests/HodaTime/Calendar/JulianTest.hs
@@ -45,7 +45,7 @@ constructorProps = testGroup "Constructor"
       convertMonth = succ . fromEnum
       testConstructor y m (Positive d) = areSame (calendarDate d m y') (fromJulianValid (fromIntegral y') (convertMonth m) d)
         where
-          y' = (y `mod` 4801) - 2400     -- NOTE: spans 2400 BC .. AD 2400 (astronomical numbering, year 0 = 1 BC)
+          y' = (y `mod` 2445) - 44     -- NOTE: spans 45 BC (year -44, the calendar's introduction) .. AD 2400
 
 lensProps :: TestTree
 lensProps = testGroup "Lens"
@@ -95,6 +95,7 @@ constructorUnits = testGroup "Constructor"
     ,testCase "1 BC (year 0) 29 February matches Data.Time" $ (ymd <$> calendarDate 29 February 0) @?= (juYmd <$> fromJulianValid 0 2 29)
     ,testCase "2 BC (year -1) is not a leap year: 29 February is invalid" $ calendarDate 29 February (-1) @?= Nothing
     ,testCase "45 BC (year -44) 1 January matches Data.Time" $ (ymd <$> calendarDate 1 January (-44)) @?= (juYmd <$> fromJulianValid (-44) 1 1)
+    ,testCase "46 BC (year -45) is before the calendar's introduction and is rejected" $ calendarDate 31 December (-45) @?= Nothing
   ]
     where
       juYmd d = let (ty, tm, td) = toJulian d in (td, tm, fromIntegral ty)

--- a/tests/HodaTime/Util.hs
+++ b/tests/HodaTime/Util.hs
@@ -89,15 +89,15 @@ instance Arbitrary (J.DayOfWeek J.Julian) where
     x <- choose (0,6)
     return $ toEnum x
 
--- | A random valid Julian date.  Unlike Gregorian (which rejects pre\-1582 dates), the Julian calendar is valid for
---   all AD years, so the range spans early\-medieval through modern years to exercise the pre\-1582 dates the calendar
---   exists to represent.  The day is capped at 28 so every generated (year, month, day) is a real date.
+-- | A random valid Julian date.  The Julian calendar runs from its introduction on 1.Jan.45 BC (astronomical year
+--   -44) with no upper bound, so the range spans 45 BC through the modern era and exercises BC (negative) years.  The
+--   day is capped at 28 so every generated (year, month, day) is a real date.
 data RandomJulianDate = RandomJulianDate Int (J.Month J.Julian) Int
   deriving (Show)
 
 instance Arbitrary RandomJulianDate where
   arbitrary = do
-    y <- choose (-2400,2400)
+    y <- choose (-44,2400)
     m <- choose (0,11)
     d <- choose (1,28)
     return $ RandomJulianDate y (toEnum m) d

--- a/tests/HodaTime/Util.hs
+++ b/tests/HodaTime/Util.hs
@@ -97,7 +97,7 @@ data RandomJulianDate = RandomJulianDate Int (J.Month J.Julian) Int
 
 instance Arbitrary RandomJulianDate where
   arbitrary = do
-    y <- choose (1,2400)
+    y <- choose (-2400,2400)
     m <- choose (0,11)
     d <- choose (1,28)
     return $ RandomJulianDate y (toEnum m) d


### PR DESCRIPTION
This pull request extends the Julian calendar implementation to support astronomical year numbering, allowing for BC (negative) years down to the calendar's introduction in 45 BC (year -44). It also refactors the Coptic and Julian calendar modules to clarify their internal epoch handling, ensuring correct conversion to and from the shared absolute timeline. Several tests are added and updated to cover the expanded date range and new behaviors.

**Julian Calendar: Astronomical Year Support and Epoch Handling**

* The Julian calendar now uses astronomical year numbering: year 1 is AD 1, year 0 is 1 BC, year -1 is 2 BC, etc., with valid dates starting from 1 January 45 BC (year -44). The code and documentation are updated to reflect this, and the lower bound for valid dates is enforced. [[1]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22L11-R27) [[2]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22L42-R59) [[3]](diffhunk://#diff-560cb262c74e6e6ba6c8f08526e253039d6af940661693c769b271bda0b6fb8bL46-R48) [[4]](diffhunk://#diff-7f87e588a5b714352b4f1f61c4fbefde0b3caebf2b0f40b3d64481d3f40abeb8L92-R100)
* The internal epoch handling is clarified: `julianEpochShift` is renamed to `julianEpochOffset`, and all conversions to and from the absolute timeline are made explicit and consistent. The offset is only applied at the Instant bridge, not internally. [[1]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22L56-R75) [[2]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22L107-R118) [[3]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22L158-L163)

**Coptic Calendar: Epoch Handling Consistency**

* The Coptic calendar module is updated to clarify its internal epoch handling, making explicit that its flat day 0 is 1 Thout 1 (29 Aug 284 Julian), and the offset to the universal timeline is only applied at the Instant bridge. [[1]](diffhunk://#diff-34922540880e9501b5da15a6c1e67a8cef24572ca34cfbe5fac621a5eaa44238L48-R50) [[2]](diffhunk://#diff-34922540880e9501b5da15a6c1e67a8cef24572ca34cfbe5fac621a5eaa44238L100-R103) [[3]](diffhunk://#diff-34922540880e9501b5da15a6c1e67a8cef24572ca34cfbe5fac621a5eaa44238L144-R151)

**Tests: Expanded Coverage for Julian Calendar**

* Property and unit tests for the Julian calendar are updated to cover the full supported range, including BC years, the correct leap year rule for year 0 (1 BC), and rejection of dates before the calendar's introduction. [[1]](diffhunk://#diff-560cb262c74e6e6ba6c8f08526e253039d6af940661693c769b271bda0b6fb8bL46-R48) [[2]](diffhunk://#diff-560cb262c74e6e6ba6c8f08526e253039d6af940661693c769b271bda0b6fb8bR94-R98) [[3]](diffhunk://#diff-7f87e588a5b714352b4f1f61c4fbefde0b3caebf2b0f40b3d64481d3f40abeb8L92-R100)

**Other Calendar Details**

* The day of week for the Julian and Coptic calendar epochs is corrected to match the new epoch definitions (`Tuesday` for Julian, `Friday` for Coptic). [[1]](diffhunk://#diff-34922540880e9501b5da15a6c1e67a8cef24572ca34cfbe5fac621a5eaa44238L62-R64) [[2]](diffhunk://#diff-5dfdc904be7d17fe72ebd7f17e4f12466916cdf4134c2d0cc733342e6aa22f22L56-R75)