### PR TITLE
Add Hebrew calendar support: implement core functionality, tests, and…

### DIFF
--- a/hodatime.cabal
+++ b/hodatime.cabal
@@ -129,6 +129,7 @@ test-suite test
                    HodaTime.Calendar.CopticTest,
                    HodaTime.Calendar.PersianTest,
                    HodaTime.Calendar.IslamicTest,
+                   HodaTime.Calendar.HebrewTest,
                    HodaTime.CalendarDateTimeTest,
                    HodaTime.ZonedDateTimeTest,
                    HodaTime.PatternTest,

--- a/src/Data/HodaTime/Calendar/Hebrew.hs
+++ b/src/Data/HodaTime/Calendar/Hebrew.hs
@@ -1,3 +1,10 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.HodaTime.Calendar.Hebrew
@@ -7,17 +14,401 @@
 -- Stability   :  experimental
 -- Portability :  POSIX, Windows
 --
--- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Hebrew' (Jewish) calendar, a lunisolar calendar that keeps its months in step with the solar year by inserting a leap month
--- seven times in each 19-year Metonic cycle.  Months can be counted in either the civil or the scriptural convention (see 'HebrewMonthNumbering').
+-- This is the module for 'CalendarDate' and 'CalendarDateTime' in the 'Hebrew' (Jewish) calendar, a lunisolar calendar that keeps its lunar months in step with the solar year by inserting a thirteenth
+-- month ('AdarI') seven times in each nineteen-year Metonic cycle (in years 3, 6, 8, 11, 14, 17 and 19).  A common year has twelve months and a leap year thirteen; two of the months ('Cheshvan' and
+-- 'Kislev') can independently gain or lose a day so that the year comes out to one of six permitted lengths (353\/354\/355 days common, 383\/384\/385 leap).  The year number changes at 1 'Tishri' (Rosh
+-- Hashanah), and dates share the same absolute timeline as every other calendar.
 --
--- Note: this calendar is not yet implemented.
+-- == Month numbering: civil vs. scriptural
+--
+-- There are two traditional ways to /number/ the Hebrew months, and — as with the Islamic leap patterns — the calendar is parameterised over the choice at the /type level/ so that a date always records which
+-- convention it uses and the type system refuses to mix the two.  The choice does not change the underlying calendar at all (the months, their lengths and the day a given date falls on are identical); it only
+-- changes which ordinal number 'fromEnum' \/ 'toEnum' assign to each month:
+--
+--     * __Civil__ (the default) counts from 'Tishri', the month of Rosh Hashanah at which the year number turns over.  This is the numbering used by the .NET @HebrewCalendar@ and is the natural one for most
+--       software: Tishri = 1, Cheshvan = 2, … , with the leap month 'AdarI' falling in the middle of the sequence in a leap year.
+--
+--     * __Scriptural__ (biblical\/ecclesiastical) counts from 'Nisan', the \"first month\" of the Exodus.  Nisan = 1, Iyar = 2, … , Tishri = 7, and the leap month 'AdarI' is numbered last (after 'Shevat'),
+--       keeping the numbers of the other twelve months fixed between common and leap years.
+--
+-- The month /constructors/ are shared across both conventions (the parameter is phantom for storage), so 'Nisan' is the same month either way — only its 'Enum' number differs.  Each convention has a type
+-- synonym, 'HebrewCivil' and 'HebrewScriptural', and 'HebrewCivil' is the default.
+--
+-- == The two Adars
+--
+-- In a common year there is a single month 'Adar'.  A leap year inserts an extra month, 'AdarI' (Adar Rishon), /before/ it; the original 'Adar' then plays the role of \"Adar II\" (Adar Sheni) and still
+-- carries Purim.  So 'Adar' is present every year and 'AdarI' exists only in leap years — attempting to build a date in 'AdarI' in a common year yields 'Nothing', exactly as an out-of-range day or year does.
 ----------------------------------------------------------------------------
 module Data.HodaTime.Calendar.Hebrew
 (
+  -- * Constructors (default civil calendar)
+   calendarDate
+  ,fromNthDay
+  ,fromWeekDate
+  -- * Constructors (choose the numbering)
+  ,calendarDate'
+  ,fromNthDay'
+  ,fromWeekDate'
+  -- * Types
+  ,Hebrew
+  ,MonthNumbering(..)
+  ,Month(..)
+  ,DayOfWeek(..)
+  ,KnownNumbering
+  -- * Named calendars (month-numbering type synonyms)
+  ,HebrewCivil
+  ,HebrewScriptural
 )
 where
 
-data HebrewMonthNumbering =
-    HebrewCivil
-  | HebrewScriptural
-  deriving (Eq, Show)
+import Data.HodaTime.CalendarDateTime.Internal (IsCalendar(..), IsCalendarDateTime(..), CalendarDate, DayNth, DayOfMonth, Year, WeekNumber, CalendarDateTime(..), LocalTime(..), Date)
+import Data.HodaTime.Instant.Internal (Instant(..))
+import Data.HodaTime.Calendar.Internal (mkFromNthDay, moveByDow, dayOfWeekFromDays)
+import Data.Int (Int32)
+import Data.List (elemIndex)
+import Data.Maybe (fromJust)
+import Data.Word (Word8)
+import Control.Monad (guard)
+
+-- types
+
+-- | The two conventions for numbering the Hebrew months, used as the (kind-'MonthNumbering') type parameter of 'Hebrew'
+--   (see the module header).
+data MonthNumbering = Civil | Scriptural
+
+-- | The Hebrew (Jewish) calendar, parameterised by its month-numbering convention (see 'MonthNumbering').
+data Hebrew (n :: MonthNumbering)
+
+-- | The Hebrew calendar numbered from 'Tishri' (the .NET @HebrewCalendar@ convention).  This is the default.
+type HebrewCivil      = Hebrew 'Civil
+-- | The Hebrew calendar numbered from 'Nisan' (the biblical \/ ecclesiastical convention).
+type HebrewScriptural = Hebrew 'Scriptural
+
+-- | Reflects a 'MonthNumbering' down to the calendar-order index at which it begins counting months: civil starts at
+--   'Tishri' (0) and scriptural at 'Nisan' (7).  Read it via @TypeApplications@, e.g. @'numberingStart' \@'Civil'@.
+class KnownNumbering (n :: MonthNumbering) where
+  numberingStart :: Int
+
+instance KnownNumbering 'Civil      where numberingStart = 0
+instance KnownNumbering 'Scriptural where numberingStart = 7   -- 'Nisan' is calendar-order index 7
+
+-- | The Hebrew calendar.  All of the field lenses and conversions run in numbering-independent calendar order; the
+--   numbering only selects how 'Month' values are numbered by 'Enum'.
+instance KnownNumbering n => IsCalendar (Hebrew n) where
+  -- | Denormalized: the flat, epoch-relative day count plus the decoded day, calendar-order month index and year.
+  data Date (Hebrew n) = HebrewDate {-# UNPACK #-} !Int32 {-# UNPACK #-} !Word8 {-# UNPACK #-} !Word8 {-# UNPACK #-} !Int32
+    deriving (Eq, Show, Ord)
+
+  -- | The Hebrew months, listed in calendar order from 'Tishri'.  'AdarI' (the leap month) sits between 'Shevat' and
+  --   'Adar'; it exists only in leap years.  The constructors are shared by both numbering conventions — only their
+  --   'Enum' numbers differ.
+  data Month (Hebrew n) =
+      Tishri | Cheshvan | Kislev | Tevet | Shevat | AdarI | Adar | Nisan | Iyar | Sivan | Tammuz | Av | Elul
+    deriving (Show, Read, Eq, Ord, Bounded)
+
+  data DayOfWeek (Hebrew n) = Sunday | Monday | Tuesday | Wednesday | Thursday | Friday | Saturday
+    deriving (Show, Read, Eq, Ord, Enum, Bounded)
+
+  fromDays = hebrewFromDays
+  toDays = hebrewToDays
+  toYmd = hebrewToYmd
+
+  day' = hebrewDayLens
+  {-# INLINE day' #-}
+
+  month' (HebrewDate _ _ ci _) = monthAt (fromIntegral ci)
+
+  monthl' = hebrewMonthLens (numberingStart @n)
+  {-# INLINE monthl' #-}
+
+  year' = hebrewYearLens
+  {-# INLINE year' #-}
+
+  dayOfWeek' (HebrewDate days _ _ _) = toEnum . dayOfWeekFromDays epochDayOfWeek . fromIntegral $ days
+
+  next' i dow (HebrewDate days _ _ _) = moveByDow hebrewFromDays epochDayOfWeek i dow (-) (+) (>) (fromIntegral days)
+
+  previous' i dow (HebrewDate days _ _ _) = moveByDow hebrewFromDays epochDayOfWeek i dow subtract (-) (<) (fromIntegral days)  -- NOTE: subtract is (-) with the arguments flipped
+
+-- | The 'Month' 'Enum' is the one place the numbering shows: it is calendar order rotated so counting begins at the
+--   numbering's start month ('numberingStart').
+instance KnownNumbering n => Enum (Month (Hebrew n)) where
+  fromEnum m = (calendarIndex m - numberingStart @n) `mod` monthCount
+  toEnum i
+    | i >= 0 && i < monthCount = monthAt ((i + numberingStart @n) `mod` monthCount)
+    | otherwise               = error "Data.HodaTime.Calendar.Hebrew: toEnum: month out of range 0..12"
+
+instance IsCalendarDateTime (Hebrew n) where
+  fromAdjustedInstant (Instant days secs nsecs) = CalendarDateTime (hebrewFromDays days) (LocalTime secs nsecs)
+  toUnadjustedInstant (CalendarDateTime hd (LocalTime secs nsecs)) = Instant (hebrewToDays hd) secs nsecs
+
+-- constructors
+
+-- | Smart constructor for a date in the default civil-numbered Hebrew calendar.  Returns 'Nothing' if the day is out of
+--   range for the month (including 'AdarI' in a common year) or the year is before 1.  Use @calendarDate'@ to select the
+--   scriptural numbering.
+calendarDate :: DayOfMonth -> Month HebrewCivil -> Year -> Maybe (CalendarDate HebrewCivil)
+calendarDate = calendarDate'
+
+-- | Smart constructor for a 'Hebrew' date in either numbering (chosen by the result type).  Returns 'Nothing' if the
+--   day is out of range for the month (including 'AdarI' in a common year) or the year is before 1.
+calendarDate' :: DayOfMonth -> Month (Hebrew n) -> Year -> Maybe (CalendarDate (Hebrew n))
+calendarDate' d m y = do
+  guard $ y >= 1
+  guard $ d > 0 && d <= maxDaysInMonth m y
+  let days = hebrewYearMonthDayToDays y (calendarIndex m) d
+  guard $ days > invalidDayThresh
+  return $ hebrewFromDays (fromIntegral days)
+
+-- | Smart constructor for the default civil calendar given as a day relative to a month (e.g. the third Monday).
+--   Returns 'Nothing' if the resulting date is invalid.
+fromNthDay :: DayNth -> DayOfWeek HebrewCivil -> Month HebrewCivil -> Year -> Maybe (CalendarDate HebrewCivil)
+fromNthDay = fromNthDay'
+
+-- | As 'fromNthDay', but in either numbering (chosen by the result type).
+fromNthDay' :: KnownNumbering n => DayNth -> DayOfWeek (Hebrew n) -> Month (Hebrew n) -> Year -> Maybe (CalendarDate (Hebrew n))
+fromNthDay' = mkFromNthDay invalidDayThresh epochDayOfWeek ymd mdim hebrewFromDays
+  where
+    ymd y m d = hebrewYearMonthDayToDays y (calendarIndex m) d
+    mdim m y = maxDaysInMonth m y
+
+-- | Smart constructor for the default civil calendar given as a week date.  Weeks are taken to start on 'Sunday' (as in
+--   the Hebrew week) and week 1 is the one containing 1.'Tishri'.
+fromWeekDate :: WeekNumber -> DayOfWeek HebrewCivil -> Year -> Maybe (CalendarDate HebrewCivil)
+fromWeekDate = fromWeekDate'
+
+-- | As 'fromWeekDate', but in either numbering (chosen by the result type).
+fromWeekDate' :: WeekNumber -> DayOfWeek (Hebrew n) -> Year -> Maybe (CalendarDate (Hebrew n))
+fromWeekDate' weekNum dow y = do
+  guard $ days > invalidDayThresh
+  return $ hebrewFromDays (fromIntegral days)
+    where
+      startOfYear = hebrewYearMonthDayToDays y 0 1                -- 1.Tishri (calendar-order index 0)
+      startDoW = dayOfWeekFromDays epochDayOfWeek startOfYear
+      weekStartDays = startOfYear - startDoW                      -- the Sunday on or before 1.Tishri
+      days = weekStartDays + pred weekNum * 7 + fromEnum dow
+
+-- helper functions
+
+-- | The Hebrew months in calendar order, starting at 'Tishri': the single source of truth for month ordering.  Both
+--   numbering conventions derive from it (civil counts from the head; scriptural is this cycle rotated to begin at
+--   'Nisan'), so their 'Enum' numbers cannot drift out of step.
+calendarMonths :: [Month (Hebrew n)]
+calendarMonths = [Tishri, Cheshvan, Kislev, Tevet, Shevat, AdarI, Adar, Nisan, Iyar, Sivan, Tammuz, Av, Elul]
+
+-- | The number of month constructors (13: the twelve common-year months plus the leap month 'AdarI').
+monthCount :: Int
+monthCount = length calendarMonths
+
+-- | A month's 0-based position in calendar order (from 'Tishri'), independent of the numbering convention.  This is
+--   the internal, storage-facing ordinal (and the civil 'Enum' number).
+calendarIndex :: Month (Hebrew n) -> Int
+calendarIndex m = fromJust (elemIndex m calendarMonths)
+
+-- | Inverse of 'calendarIndex', checked against the valid 0..12 range.
+monthAt :: Int -> Month (Hebrew n)
+monthAt i
+  | i >= 0 && i < monthCount = calendarMonths !! i
+  | otherwise               = error "Data.HodaTime.Calendar.Hebrew: month index out of range 0..12"
+
+-- | Calendar-order index of the leap month 'AdarI'.
+adarICalIndex :: Int
+adarICalIndex = 5
+
+-- | Calendar-order index of 'Adar' (\"Adar II\" in a leap year).
+adarCalIndex :: Int
+adarCalIndex = 6
+
+-- | Hebrew dates are stored directly on the universal timeline (day 0 = 1.Mar.2000 Gregorian = Wednesday), so the
+--   'Instant' bridge is the identity and the epoch weekday is that of the shared day 0.
+epochDayOfWeek :: DayOfWeek (Hebrew n)
+epochDayOfWeek = Wednesday
+
+-- | The day before 1.Tishri.1: a day is \"before the calendar starts\" when it is on or before this.
+invalidDayThresh :: Int
+invalidDayThresh = pred (firstDayOfYear 1)
+
+-- | Anchors the molad-based day count to the shared timeline: the universal flat day of 1.Tishri.1 (the Hebrew epoch,
+--   Rata Die -1373427 = universal day -2103607) less @'elapsedDays' 1@ (which is 1).  So
+--   @'firstDayOfYear' = 'hebrewRefDay' + 'elapsedDays'@.
+hebrewRefDay :: Int
+hebrewRefDay = -2103608
+
+-- Molad and Rosh Hashanah
+
+-- | A year is a leap year (thirteen months) in 7 of every 19 (years 3, 6, 8, 11, 14, 17 and 19 of the Metonic cycle).
+isLeapYear :: Year -> Bool
+isLeapYear y = (7 * y + 1) `mod` 19 < 7
+
+-- | Number of months in a year (12 common, 13 leap).
+monthsInYear :: Year -> Int
+monthsInYear y = if isLeapYear y then 13 else 12
+
+-- | Lunar months from the epoch molad to the molad of 'Tishri' of the given year.
+monthsElapsed :: Year -> Int
+monthsElapsed year = 235 * cycles + 12 * inCycle + (7 * inCycle + 1) `div` 19
+  where (cycles, inCycle) = (year - 1) `divMod` 19
+
+-- | Days from the epoch molad to 1.Tishri of the given year after the four postponement rules (dechiyot): the molad
+--   rules (molad zaken, and the GaTaRaD \/ BeTUTaKPaT year-length fixes) and \"lo ADU rosh\" (Rosh Hashanah may not
+--   fall on Sunday, Wednesday or Friday).  A part (chelek) is 1\/1080 of an hour, so a day is 25920 parts.
+elapsedDays :: Year -> Int
+elapsedDays year = aduAdjusted
+  where
+    m = monthsElapsed year
+    partsElapsed = 204 + 793 * (m `mod` 1080)
+    hoursElapsed = 5 + 12 * m + 793 * (m `div` 1080) + partsElapsed `div` 1080
+    moladDay = 1 + 29 * m + hoursElapsed `div` 24
+    moladParts = 1080 * (hoursElapsed `mod` 24) + partsElapsed `mod` 1080
+    postponed
+      | moladParts >= 19440                                                   = moladDay + 1   -- molad zaken (molad at or after 18h)
+      | moladDay `mod` 7 == 2 && moladParts >= 9924  && not (isLeapYear year) = moladDay + 1   -- GaTaRaD (Tue, 9h204p, common year)
+      | moladDay `mod` 7 == 1 && moladParts >= 16789 && isLeapYear (year - 1) = moladDay + 1   -- BeTUTaKPaT (Mon, 15h589p, year after leap)
+      | otherwise                                                             = moladDay
+    aduAdjusted = if postponed `mod` 7 `elem` [0, 3, 5] then postponed + 1 else postponed
+
+-- | Universal flat day (day 0 = 1.Mar.2000 Gregorian) of 1.Tishri of the given year (Rosh Hashanah).
+firstDayOfYear :: Year -> Int
+firstDayOfYear year = hebrewRefDay + elapsedDays year
+
+-- | Length of the given year in days (353\/354\/355 common, 383\/384\/385 leap).
+daysInYear :: Year -> Int
+daysInYear year = firstDayOfYear (year + 1) - firstDayOfYear year
+
+-- | In a \"complete\" (shelemah) year 'Cheshvan' has 30 days instead of 29.
+isCheshvanLong :: Year -> Bool
+isCheshvanLong year = daysInYear year `mod` 10 == 5
+
+-- | In a \"deficient\" (chaserah) year 'Kislev' has 29 days instead of 30.
+isKislevShort :: Year -> Bool
+isKislevShort year = daysInYear year `mod` 10 == 3
+
+-- | Length of the month at the given calendar-order index in the given year (0 for 'AdarI' in a common year, so any
+--   day in it is out of range).
+monthLengthByIndex :: Year -> Int -> Int
+monthLengthByIndex year ci = case ci of
+  0  -> 30                                    -- Tishri
+  1  -> if isCheshvanLong year then 30 else 29-- Cheshvan
+  2  -> if isKislevShort  year then 29 else 30-- Kislev
+  3  -> 29                                    -- Tevet
+  4  -> 30                                    -- Shevat
+  5  -> if isLeapYear year then 30 else 0     -- AdarI (leap years only)
+  6  -> 29                                    -- Adar (Adar II in leap years)
+  7  -> 30                                    -- Nisan
+  8  -> 29                                    -- Iyar
+  9  -> 30                                    -- Sivan
+  10 -> 29                                    -- Tammuz
+  11 -> 30                                    -- Av
+  12 -> 29                                    -- Elul
+  _  -> 0
+
+-- | Maximum day for a month in a given year (0 for 'AdarI' in a common year, so such a date is always rejected).
+maxDaysInMonth :: Month (Hebrew n) -> Year -> Int
+maxDaysInMonth m year = monthLengthByIndex year (calendarIndex m)
+
+-- | Days elapsed in the year before the first of the month at the given calendar-order index.
+daysBeforeMonth :: Year -> Int -> Int
+daysBeforeMonth year ci = sum [monthLengthByIndex year i | i <- [0 .. ci - 1]]
+
+-- Date <-> day count
+
+-- | Universal flat day (day 0 = 1.Mar.2000 Gregorian) of the given year, calendar-order month index and day.
+hebrewYearMonthDayToDays :: Year -> Int -> DayOfMonth -> Int
+hebrewYearMonthDayToDays year ci d = firstDayOfYear year + daysBeforeMonth year ci + d - 1
+
+-- | Decode a universal flat day to @(year, calendar-order month index, day)@.
+hebrewDaysToYmd :: Int32 -> (Int32, Word8, Word8)
+hebrewDaysToYmd flatDays = (fromIntegral year, fromIntegral ci, fromIntegral d)
+  where
+    n = fromIntegral flatDays :: Int
+    year = findYear (estimate n)
+    (ci, d) = findMonth 0 (n - firstDayOfYear year)
+    findMonth i remaining
+      | remaining < len = (i, remaining + 1)                  -- a 0-length AdarI in a common year is skipped here
+      | otherwise       = findMonth (i + 1) (remaining - len)
+      where len = monthLengthByIndex year i
+    -- a Hebrew year averages ~365.25 days, so dividing by 366 gives a safe under-estimate to search up from
+    estimate d0 = max 1 $ (d0 - firstDayOfYear 1) `div` 366 + 1
+    findYear y
+      | firstDayOfYear y > n        = findYear (y - 1)
+      | firstDayOfYear (y + 1) <= n = findYear (y + 1)
+      | otherwise                   = y
+
+-- | Build the flat Hebrew date (denormalized: keeps the day count plus the decoded day\/calendar-month\/year).
+hebrewFromDays :: Int32 -> Date (Hebrew n)
+hebrewFromDays flatDays = HebrewDate flatDays d ci y
+  where (y, ci, d) = hebrewDaysToYmd flatDays
+
+hebrewToDays :: Date (Hebrew n) -> Int32
+hebrewToDays (HebrewDate flatDays _ _ _) = flatDays
+
+hebrewToYmd :: Date (Hebrew n) -> (Int32, Word8, Word8)
+hebrewToYmd (HebrewDate _ d ci y) = (y, ci, d)
+
+-- lenses (Hebrew-specific: the shared helpers assume a fixed month count and that the stored month index equals the
+-- numbering's Enum number, neither of which holds here, so these work in numbering-independent calendar-index space)
+
+-- | Day-of-month lens: shifts the flat day directly, so overflowing the month rolls into the next (not clamped).
+hebrewDayLens :: Functor f => (DayOfMonth -> f DayOfMonth) -> Date (Hebrew n) -> f (Date (Hebrew n))
+hebrewDayLens f date = rebuild <$> f (fromIntegral d)
+  where
+    (y, ci, d) = hebrewToYmd date
+    startOfMonth = pred $ hebrewYearMonthDayToDays (fromIntegral y) (fromIntegral ci) 1
+    rebuild newDay = hebrewFromDays (fromIntegral days)
+      where
+        raw = startOfMonth + newDay
+        days = if raw > invalidDayThresh then raw else invalidDayThresh + 1
+
+-- | Month lens.  The exposed 'Int' is the month in the calendar's numbering; adding to it moves that many months in
+--   calendar order (carrying the year at 'Tishri' and skipping the absent 'AdarI' in common years), clamping the day.
+hebrewMonthLens :: Functor f => Int -> (Int -> f Int) -> Date (Hebrew n) -> f (Date (Hebrew n))
+hebrewMonthLens start f date = rebuild <$> f current
+  where
+    (y, ci, d) = hebrewToYmd date
+    yr = fromIntegral y
+    cur = fromIntegral ci
+    current = (cur - start) `mod` monthCount
+    rebuild target = hebrewFromDays (fromIntegral days)
+      where
+        (y', ci') = addMonthsChrono yr cur (target - current)
+        mdim = monthLengthByIndex (max 1 y') ci'
+        d' = min (fromIntegral d) mdim
+        raw = hebrewYearMonthDayToDays (max 1 y') ci' d'
+        days = if raw > invalidDayThresh then raw else invalidDayThresh + 1
+
+-- | Year lens: keeps the month and day (clamping the day, and moving 'AdarI' to 'Adar' when the target year is common).
+hebrewYearLens :: Functor f => (Year -> f Year) -> Date (Hebrew n) -> f (Date (Hebrew n))
+hebrewYearLens f date = rebuild <$> f (fromIntegral y)
+  where
+    (y, ci, d) = hebrewToYmd date
+    rebuild newYear = hebrewFromDays (fromIntegral days)
+      where
+        y' = max 1 newYear
+        ci' = if fromIntegral ci == adarICalIndex && not (isLeapYear y') then adarCalIndex else fromIntegral ci
+        mdim = monthLengthByIndex y' ci'
+        d' = min (fromIntegral d) mdim
+        days = hebrewYearMonthDayToDays y' ci' d'
+
+-- | Move a @(year, calendar-order month index)@ by a number of months in calendar order, carrying the year at 'Tishri'
+--   and stepping over the absent 'AdarI' in common years.
+addMonthsChrono :: Year -> Int -> Int -> (Year, Int)
+addMonthsChrono year ci delta = go year (calIndexToPos year ci + delta)
+  where
+    go y p
+      | p < 0               = go (y - 1) (p + monthsInYear (y - 1))
+      | p >= monthsInYear y = go (y + 1) (p - monthsInYear y)
+      | otherwise           = (y, posToCalIndex y p)
+
+-- | Calendar-order index to sequential position within the year (common years have no 'AdarI', so 'Adar' onward shift down).
+calIndexToPos :: Year -> Int -> Int
+calIndexToPos year ci
+  | isLeapYear year    = ci
+  | ci < adarICalIndex = ci
+  | otherwise          = ci - 1
+
+-- | Inverse of 'calIndexToPos'.
+posToCalIndex :: Year -> Int -> Int
+posToCalIndex year p
+  | isLeapYear year   = p
+  | p < adarICalIndex = p
+  | otherwise         = p + 1

--- a/tests/HodaTime/Calendar/HebrewTest.hs
+++ b/tests/HodaTime/Calendar/HebrewTest.hs
@@ -1,0 +1,131 @@
+module HodaTime.Calendar.HebrewTest
+(
+  hebrewTests
+)
+where
+
+import Test.Tasty
+import Test.Tasty.QuickCheck as QC
+import Test.Tasty.HUnit
+import Data.Maybe (fromJust)
+import Data.Time.Calendar (Day, fromGregorian)
+import Data.Time.Clock (UTCTime(..))
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+
+import HodaTime.Util
+import Data.HodaTime.CalendarDate (day, monthl, month, year, next, previous, dayOfWeek, DayNth(..), CalendarDate)
+import Data.HodaTime.Calendar.Hebrew (calendarDate, calendarDate', fromNthDay, fromWeekDate, HebrewCivil, HebrewScriptural, Month(..), DayOfWeek(..))
+import Data.HodaTime.Instant (fromSecondsSinceUnixEpoch)
+import Data.HodaTime.TimeZone (utc)
+import Data.HodaTime.ZonedDateTime (fromInstant, ZonedDateTime)
+import qualified Data.HodaTime.ZonedDateTime as Z
+
+hebrewTests :: TestTree
+hebrewTests = testGroup "Hebrew Tests" [qcProps, unitTests]
+
+qcProps :: TestTree
+qcProps = testGroup "(checked by QuickCheck)" [roundTripProps, lensProps, nthDayProps]
+
+unitTests :: TestTree
+unitTests = testGroup "Unit tests" [structureUnits, numberingUnits, crossCalendarUnits]
+
+-- | Decode a civil Hebrew date to (day, 1-based civil month, year) for explicit expected-value assertions.
+ymd :: CalendarDate HebrewCivil -> (Int, Int, Int)
+ymd x = (get day x, succ . fromEnum $ month x, get year x)
+
+-- | Data.Time has no Hebrew calendar, so we verify the construct -> decode bijection directly.  'RandomHebrewDate'
+--   only generates valid dates (the leap month 'AdarI' in leap years, the swing months capped at their shorter length).
+roundTripProps :: TestTree
+roundTripProps = testGroup "Constructor"
+  [
+    QC.testProperty "construct -> decode round-trips" testRoundTrip
+  ]
+  where
+    testRoundTrip (RandomHebrewDate y m d) = (ymd <$> calendarDate d m y) == Just (d, succ (fromEnum m), y)
+
+lensProps :: TestTree
+lensProps = testGroup "Lens"
+  [
+     QC.testProperty "dayOfWeek . next n dow $ date == dow" testNextDoW
+    ,QC.testProperty "next n (dayOfWeek date) date == modify (+ n * 7) day date" $ testDirection next (+)
+    ,QC.testProperty "previous n (dayOfWeek date) date == modify (- n * 7) day date" $ testDirection previous $ flip (-)
+  ]
+  where
+    anchorDay = fromJust $ calendarDate 1 Tishri 5784
+    testNextDoW dow (Positive n) = (dayOfWeek . next n dow $ anchorDay) == dow
+    testDirection dir adjust (Positive n) = dir n (dayOfWeek anchorDay) anchorDay == modify (adjust $ n * 7) day anchorDay
+
+-- | 'fromNthDay' and 'fromWeekDate' are the generic constructors instantiated for Hebrew.  Every Hebrew month has at
+--   least 29 days, so a given weekday always occurs and the properties are total.
+nthDayProps :: TestTree
+nthDayProps = testGroup "fromNthDay / fromWeekDate"
+  [
+     QC.testProperty "fromNthDay First dow is the first such weekday (day 1..7)" testFirst
+    ,QC.testProperty "fromNthDay Last dow is the last such weekday (final week)" testLast
+    ,QC.testProperty "fromWeekDate lands on the requested day-of-week" testWeekDoW
+  ]
+  where
+    testFirst dow (RandomHebrewDate y m _) = let r = fromNthDay First dow m y in (dayOfWeek <$> r) == Just dow && maybe False (\d -> get day d >= 1 && get day d <= 7) r
+    testLast dow (RandomHebrewDate y m _) = let r = fromNthDay Last dow m y in (dayOfWeek <$> r) == Just dow && maybe False (\d -> get day d >= 22) r
+    testWeekDoW dow (RandomHebrewDate y _ _) = maybe True ((== dow) . dayOfWeek) (fromWeekDate 1 dow y)
+
+-- | The interesting Hebrew structure: the leap month 'AdarI' (present only in leap years) and the two swing months
+--   'Cheshvan' \/ 'Kislev' (29 or 30 days depending on the year).  Concrete years: 5784 is leap (deficient); 5783 is a
+--   complete common year (Cheshvan 30, Kislev 30); 5786 is a regular common year (Cheshvan 29, Kislev 30); 5781 is a
+--   deficient common year (Cheshvan 29, Kislev 29).
+structureUnits :: TestTree
+structureUnits = testGroup "Structure"
+  [
+     testCase "30 Tishri 5784 is valid (Tishri always has 30 days)"          $ (ymd <$> calendarDate 30 Tishri 5784) @?= Just (30, 1, 5784)
+    ,testCase "29 Adar 5786 is valid (Adar always has 29 days)"              $ (ymd <$> calendarDate 29 Adar 5786) @?= Just (29, 7, 5786)
+    ,testCase "30 Cheshvan 5783 is valid (complete year)"                    $ (ymd <$> calendarDate 30 Cheshvan 5783) @?= Just (30, 2, 5783)
+    ,testCase "30 Cheshvan 5786 is invalid (regular year: Cheshvan has 29)"  $ calendarDate 30 Cheshvan 5786 @?= Nothing
+    ,testCase "30 Kislev 5786 is valid (regular year: Kislev has 30)"        $ (ymd <$> calendarDate 30 Kislev 5786) @?= Just (30, 3, 5786)
+    ,testCase "30 Kislev 5781 is invalid (deficient year: Kislev has 29)"    $ calendarDate 30 Kislev 5781 @?= Nothing
+    ,testCase "30 AdarI 5784 is valid (leap year has the extra month)"       $ (ymd <$> calendarDate 30 AdarI 5784) @?= Just (30, 6, 5784)
+    ,testCase "1 AdarI 5786 is invalid (common year has no AdarI)"           $ calendarDate 1 AdarI 5786 @?= Nothing
+    ,testCase "1 Shevat 5784 + 1 month == 1 AdarI (leap year keeps AdarI)"   $ (ymd <$> (modify (+1) monthl <$> calendarDate 1 Shevat 5784)) @?= Just (1, 6, 5784)
+    ,testCase "1 Shevat 5784 + 2 months == 1 Adar (leap year)"               $ (ymd <$> (modify (+2) monthl <$> calendarDate 1 Shevat 5784)) @?= Just (1, 7, 5784)
+    ,testCase "1 Shevat 5786 + 1 month == 1 Adar (common year skips AdarI)"  $ (ymd <$> (modify (+1) monthl <$> calendarDate 1 Shevat 5786)) @?= Just (1, 7, 5786)
+    ,testCase "1 Elul 5785 + 1 month == 1 Tishri 5786 (year rolls at Tishri)"$ (ymd <$> (modify (+1) monthl <$> calendarDate 1 Elul 5785)) @?= Just (1, 1, 5786)
+    ,testCase "30 AdarI 5784 + 1 year == 29 Adar 5785 (AdarI -> Adar, common)"$ (ymd <$> (modify (+1) year <$> calendarDate 30 AdarI 5784)) @?= Just (29, 7, 5785)
+    ,testCase "year 0 is out of range"                                       $ calendarDate 1 Tishri 0 @?= Nothing
+  ]
+
+-- | The numbering is carried in the type: the same physical date is numbered differently by civil ('Tishri' = 1) and
+--   scriptural ('Nisan' = 1) conventions, but the underlying day, month value and year are identical.
+numberingUnits :: TestTree
+numberingUnits = testGroup "Month numbering (civil vs scriptural)"
+  [
+     testCase "civil: Tishri is month 1"                      $ fromEnum (Tishri :: Month HebrewCivil) @?= 0
+    ,testCase "scriptural: Tishri is month 7"                 $ fromEnum (Tishri :: Month HebrewScriptural) @?= 6
+    ,testCase "civil: Nisan is month 8"                       $ fromEnum (Nisan :: Month HebrewCivil) @?= 7
+    ,testCase "scriptural: Nisan is month 1"                  $ fromEnum (Nisan :: Month HebrewScriptural) @?= 0
+    ,testCase "civil: toEnum 0 == Tishri"                     $ (toEnum 0 :: Month HebrewCivil) @?= Tishri
+    ,testCase "scriptural: toEnum 0 == Nisan"                 $ (toEnum 0 :: Month HebrewScriptural) @?= Nisan
+    ,testCase "same date is Nisan (civil), numbered 8"        $ (succ . fromEnum . month <$> calendarDate 15 Nisan 5784) @?= Just 8
+    ,testCase "same date is Nisan (scriptural), numbered 1"   $ (succ . fromEnum . month <$> scripturalNisan) @?= Just 1
+    ,testCase "numbering does not move the day/year"          $ (dayYear <$> calendarDate 15 Nisan 5784, dayYear <$> scripturalNisan) @?= (Just (15, 5784), Just (15, 5784))
+  ]
+  where
+    scripturalNisan = calendarDate' 15 Nisan 5784 :: Maybe (CalendarDate HebrewScriptural)
+    dayYear x = (get day x, get year x)
+
+-- | The strongest checks: the same absolute day, anchored via Data.Time, must decode to the expected Hebrew date.  The
+--   anchors are well-known Gregorian equivalents (Rosh Hashanah of three years and Passover), independently verified.
+crossCalendarUnits :: TestTree
+crossCalendarUnits = testGroup "Cross-calendar (Instant)"
+  [
+     testCase "16.Sep.2023 (Gregorian) is 1 Tishri 5784 (Rosh Hashanah)"  $ hebrewOfDay (fromGregorian 2023 9 16) >>= (@?= (5784, 1, 1))
+    ,testCase "23.Apr.2024 (Gregorian) is 15 Nisan 5784 (Passover)"       $ hebrewOfDay (fromGregorian 2024 4 23) >>= (@?= (5784, 8, 15))
+    ,testCase "3.Oct.2024 (Gregorian) is 1 Tishri 5785 (Rosh Hashanah)"   $ hebrewOfDay (fromGregorian 2024 10 3) >>= (@?= (5785, 1, 1))
+    ,testCase "23.Sep.2025 (Gregorian) is 1 Tishri 5786 (Rosh Hashanah)"  $ hebrewOfDay (fromGregorian 2025 9 23) >>= (@?= (5786, 1, 1))
+  ]
+
+-- | View the UTC midnight of a Data.Time 'Day' as a civil Hebrew date, returning (year, 1-based civil month, day).
+hebrewOfDay :: Day -> IO (Int, Int, Int)
+hebrewOfDay dt = do
+  tz <- utc
+  let secs = round (utcTimeToPOSIXSeconds (UTCTime dt 0))
+      zdt = fromInstant (fromSecondsSinceUnixEpoch secs) tz :: ZonedDateTime HebrewCivil
+  return (Z.year zdt, succ (fromEnum (Z.month zdt)), Z.day zdt)

--- a/tests/HodaTime/Util.hs
+++ b/tests/HodaTime/Util.hs
@@ -9,13 +9,14 @@ module HodaTime.Util
   ,RandomCopticDate(..)
   ,RandomPersianDate(..)
   ,RandomIslamicDate(..)
+  ,RandomHebrewDate(..)
   ,get
   ,modify
   ,set
 )
 where
 
-import Test.Tasty.QuickCheck (Arbitrary(..), choose)
+import Test.Tasty.QuickCheck (Arbitrary(..), choose, elements)
 
 import Control.Applicative (Const(..))
 import Data.Functor.Identity (Identity(..))
@@ -25,6 +26,7 @@ import qualified Data.HodaTime.Calendar.Julian as J
 import qualified Data.HodaTime.Calendar.Coptic as C
 import qualified Data.HodaTime.Calendar.Persian as P
 import qualified Data.HodaTime.Calendar.Islamic as I
+import qualified Data.HodaTime.Calendar.Hebrew as H
 
 -- arbitrary data and instances
 
@@ -173,6 +175,39 @@ instance Arbitrary RandomIslamicDate where
     m <- choose (0,11)
     d <- if even m then choose (1,30) else choose (1,29)
     return $ RandomIslamicDate y (toEnum m) d
+
+instance Arbitrary (H.Month H.HebrewCivil) where
+  arbitrary = do
+    x <- choose (0,12)
+    return $ toEnum x
+
+instance Arbitrary (H.DayOfWeek H.HebrewCivil) where
+  arbitrary = do
+    x <- choose (0,6)
+    return $ toEnum x
+
+-- | The Hebrew months in calendar order, each paired with a day it is always safe to generate.  'Cheshvan' and
+--   'Kislev' are the two swing months (29 or 30 days depending on the year), so they are capped at their shorter length
+--   of 29; every other length is fixed.  'AdarI' (the leap month) is only ever included for leap years (see below).
+hebrewMonthCaps :: [(H.Month H.HebrewCivil, Int)]
+hebrewMonthCaps =
+  [ (H.Tishri, 30), (H.Cheshvan, 29), (H.Kislev, 29), (H.Tevet, 29), (H.Shevat, 30)
+  , (H.AdarI, 30), (H.Adar, 29), (H.Nisan, 30), (H.Iyar, 29), (H.Sivan, 30)
+  , (H.Tammuz, 29), (H.Av, 30), (H.Elul, 29) ]
+
+-- | A random valid Hebrew (civil) date.  A common year has no leap month, so 'AdarI' is offered only in leap years
+--   (Metonic years 3, 6, 8, 11, 14, 17, 19); the swing months 'Cheshvan' and 'Kislev' are capped at their shorter
+--   length so every generated (year, month, day) is a real date regardless of the year's exact length.
+data RandomHebrewDate = RandomHebrewDate Int (H.Month H.HebrewCivil) Int
+  deriving (Show)
+
+instance Arbitrary RandomHebrewDate where
+  arbitrary = do
+    y <- choose (1,6000)
+    let months = if (7 * y + 1) `mod` 19 < 7 then hebrewMonthCaps else filter ((/= H.AdarI) . fst) hebrewMonthCaps
+    (m, cap) <- elements months
+    d <- choose (1,cap)
+    return $ RandomHebrewDate y m d
 
 -- Lenses
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -9,6 +9,7 @@ import HodaTime.Calendar.JulianTest
 import HodaTime.Calendar.CopticTest
 import HodaTime.Calendar.PersianTest
 import HodaTime.Calendar.IslamicTest
+import HodaTime.Calendar.HebrewTest
 import HodaTime.CalendarDateTimeTest
 import HodaTime.ZonedDateTimeTest
 import HodaTime.PatternTest
@@ -18,7 +19,7 @@ main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "Tests" [instantTests, durationTests, offsetTests, localTimeTests, gregorianTests, julianTests, copticTests, persianTests, islamicTests, calendarDateTimeTests, zonedDateTimeTests, patternTests, withCalendarTests]
+tests = testGroup "Tests" [instantTests, durationTests, offsetTests, localTimeTests, gregorianTests, julianTests, copticTests, persianTests, islamicTests, hebrewTests, calendarDateTimeTests, zonedDateTimeTests, patternTests, withCalendarTests]
 
 {-
 unitTests :: TestTree


### PR DESCRIPTION
This pull request adds comprehensive property-based and unit tests for the Hebrew calendar implementation in HodaTime, ensuring correctness and coverage for Hebrew date logic. It introduces a new `HebrewTest` module, integrates it into the test suite, and provides generators for random valid Hebrew dates.

**New Hebrew calendar tests and test utilities:**

* Added the `HodaTime.Calendar.HebrewTest` module with extensive QuickCheck properties and unit tests for Hebrew calendar structure, numbering, and cross-calendar validation.
* Registered `HebrewTest` in the test suite configuration (`hodatime.cabal`), test runner imports (`tests/test.hs`), and the main test group to ensure the tests are executed. [[1]](diffhunk://#diff-34273afbd85940057361cf5f2bc34c0f9ef907c3d658751ba6bd3a77212e7e03R132) [[2]](diffhunk://#diff-b3e2981be7a6ba18e5296c23cd90a3034132d24277c8322bb7b430e59f42e3feR12) [[3]](diffhunk://#diff-b3e2981be7a6ba18e5296c23cd90a3034132d24277c8322bb7b430e59f42e3feL21-R22)

**Test data generation enhancements:**

* Added `RandomHebrewDate` type and `Arbitrary` instance to generate valid random Hebrew dates, including logic for leap years and month length variations.
* Exported `RandomHebrewDate` from `HodaTime.Util` and imported Hebrew calendar modules as needed for test support. [[1]](diffhunk://#diff-7f87e588a5b714352b4f1f61c4fbefde0b3caebf2b0f40b3d64481d3f40abeb8R12-R19) [[2]](diffhunk://#diff-7f87e588a5b714352b4f1f61c4fbefde0b3caebf2b0f40b3d64481d3f40abeb8R29)… integrate into the project