### PR TITLE
Toolchain

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,53 +8,44 @@ on:
 permissions:
   contents: read
 
-jobs:      
+jobs:
   test:
-    name: test
+    name: test / ${{ matrix.os }} / ${{ matrix.snapshot }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        # NOTE: macos-latest runners are Apple Silicon (aarch64). The current stack resolver (lts-16.15 / GHC 8.8.4)
-        # has no aarch64 macOS GHC binary (support starts at GHC 8.10.5). Re-add 'macos-latest' below once the
-        # resolver is bumped to one that ships an aarch64 GHC (>= 8.10.5).
-        os: [ubuntu-latest, windows-latest] # , macos-latest
+        # Test the full modern GHC window (9.4 -> 9.10) on Linux, and smoke-test the
+        # latest snapshot on macOS and Windows. Snapshot -> GHC:
+        #   lts-21.25 -> 9.4.8, lts-22.44 -> 9.6.7, lts-23.28 -> 9.8.4, lts-24.52 -> 9.10.3
+        os: [ubuntu-latest]
+        snapshot: [lts-21.25, lts-22.44, lts-23.28, lts-24.52]
+        include:
+          - os: macos-latest
+            snapshot: lts-24.52
+          - os: windows-latest
+            snapshot: lts-24.52
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Install stack (Windows)
-        run: choco install haskell-stack
-        if: matrix.os == 'windows-latest'
-
-      # Re-enable together with 'macos-latest' in the matrix once the resolver ships an aarch64 GHC (>= 8.10.5).
-      # - name: Install stack (macOS)
-      #   run: brew install haskell-stack
-      #   if: matrix.os == 'macos-latest'
-
-      - name: Cache dependencies (Unix)
-        uses: actions/cache@v4
-        if: matrix.os != 'windows-latest'
+      - name: Set up Haskell (stack)
+        id: setup
+        uses: haskell-actions/setup@v2
         with:
-          path: ~/.stack
-          key: ${{ runner.os }}-store-${{ hashFiles('generator/stack.yaml.lock') }}-${{ hashFiles('generator/generator.cabal') }}
+          enable-stack: true
+          stack-version: latest
 
-      - name: Cache dependencies (Windows)
+      - name: Cache stack root
         uses: actions/cache@v4
-        if: matrix.os == 'windows-latest'
         with:
-          path: 'C:\Users\runneradmin\AppData\Roaming\stack'
-          key: ${{ runner.os }}-store-${{ hashFiles('generator/stack.yaml.lock') }}-${{ hashFiles('generator/generator.cabal') }}
-
-      - name: Cache GHC (Windows)
-        uses: actions/cache@v4
-        if: matrix.os == 'windows-latest'
-        with:
-          path: 'C:\Users\runneradmin\AppData\Local\Programs\stack'
-          key: ghc-${{ hashFiles('generator/stack.yaml.lock') }}
+          path: ${{ steps.setup.outputs.stack-root }}
+          key: ${{ runner.os }}-${{ matrix.snapshot }}-stack-${{ hashFiles('hodatime.cabal', 'stack.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.snapshot }}-stack-
 
       - name: test project
-        run: stack test
+        run: stack test --resolver ${{ matrix.snapshot }} --no-terminal
 
   publish:
     name: publish hackage
@@ -64,6 +55,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      - name: Set up Haskell (cabal)
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.6.7'
+          cabal-version: latest
 
       - name: get version
         run: |

--- a/hodatime.cabal
+++ b/hodatime.cabal
@@ -1,9 +1,9 @@
+cabal-version:  2.4
 name:           hodatime
 version:        0.2.2.1
 stability:      experimental
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   LICENSE
-cabal-version:  >=1.10
 build-type:     Simple
 author:         Jason Johnson
 maintainer:     <jason.johnson.081@gmail.com>
@@ -12,7 +12,7 @@ bug-reports:    https://github.com/jason-johnson/hodatime/issues
 synopsis:       A fully featured date/time library based on Nodatime
 description:    A library for dealing with time, dates, calendars and time zones
 category:       Data, Time
-tested-with:    GHC == 8.8.4
+tested-with:    GHC == 9.4.8 || == 9.6.7 || == 9.8.4 || == 9.10.3
 extra-source-files:
                    platform/osx/Data/HodaTime/TimeZone/Platform.hs
                    platform/osx/Data/HodaTime/Instant/Platform.hs
@@ -40,7 +40,7 @@ library
     hs-source-dirs: platform/windows
 
   build-depends:
-                   base >= 4.9 && < 5,
+                   base >= 4.16 && < 4.21,
                    mtl,
                    binary,
                    bytestring,

--- a/platform/windows/Data/HodaTime/TimeZone/Platform.hs
+++ b/platform/windows/Data/HodaTime/TimeZone/Platform.hs
@@ -113,7 +113,7 @@ systemTimeToNthDayExpression (SYSTEMTIME _ m d nth h mm s _) offsetSecs = NthDay
 readLocalZoneName :: IO String
 readLocalZoneName =
   bracket op regCloseKey $ \key ->
-  regQueryValue key "TimeZoneKeyName"
+  regQueryValue key (Just "TimeZoneKeyName")
     where
       op = regOpenKeyEx hKEY_LOCAL_MACHINE hive kEY_QUERY_VALUE
       hive = "SYSTEM\\CurrentControlSet\\Control\\TimeZoneInformation"
@@ -129,8 +129,8 @@ readAllZoneNames =
 readTziForZone :: String -> IO (String, String, REG_TZI_FORMAT)
 readTziForZone zone =
   bracket op regCloseKey $ \key -> do
-    std <- regQueryValue key "Std"
-    dst <- regQueryValue key "Dlt"
+    std <- regQueryValue key (Just "Std")
+    dst <- regQueryValue key (Just "Dlt")
     tzi <- readTzi key "TZI"
     return (std, dst, tzi)
     where

--- a/platform/windows/Data/HodaTime/TimeZone/Platform.hs
+++ b/platform/windows/Data/HodaTime/TimeZone/Platform.hs
@@ -18,7 +18,7 @@ import Data.Char (isDigit)
 import Data.List (sortOn, foldl')
 import Control.Monad (forM)
 import Control.Exception (bracket)
-import System.Win32.Types (LONG, HKEY)
+import System.Win32.Types (LONG, HKEY, peekTString)
 import System.Win32.Registry
 import System.Win32.Time (SYSTEMTIME(..))
 import Foreign.Marshal.Alloc (allocaBytes)
@@ -113,7 +113,7 @@ systemTimeToNthDayExpression (SYSTEMTIME _ m d nth h mm s _) offsetSecs = NthDay
 readLocalZoneName :: IO String
 readLocalZoneName =
   bracket op regCloseKey $ \key ->
-  regQueryValue key (Just "TimeZoneKeyName")
+  regQueryValueString key "TimeZoneKeyName"
     where
       op = regOpenKeyEx hKEY_LOCAL_MACHINE hive kEY_QUERY_VALUE
       hive = "SYSTEM\\CurrentControlSet\\Control\\TimeZoneInformation"
@@ -129,8 +129,8 @@ readAllZoneNames =
 readTziForZone :: String -> IO (String, String, REG_TZI_FORMAT)
 readTziForZone zone =
   bracket op regCloseKey $ \key -> do
-    std <- regQueryValue key (Just "Std")
-    dst <- regQueryValue key (Just "Dlt")
+    std <- regQueryValueString key "Std"
+    dst <- regQueryValueString key "Dlt"
     tzi <- readTzi key "TZI"
     return (std, dst, tzi)
     where
@@ -169,3 +169,15 @@ readTzi key p =
     verifyAndPeak rvt ptr
         | rvt == rEG_BINARY = peek . castPtr $ ptr
         | otherwise         = error $ "registry corrupt: TZI variable was non-binary type: " ++ show rvt
+
+-- | Read a named REG_SZ (or REG_EXPAND_SZ) value as a 'String'.  Note: 'regQueryValue' reads the /default/ value of a
+--   subkey, not a named value, so named string values (Std, Dlt, TimeZoneKeyName) must go through 'regQueryValueEx'.
+regQueryValueString :: HKEY -> String -> IO String
+regQueryValueString key name =
+  allocaBytes sz $ \ptr -> do
+    rvt <- regQueryValueEx key name ptr sz
+    if rvt == rEG_SZ || rvt == rEG_EXPAND_SZ
+      then peekTString (castPtr ptr)
+      else error $ "registry corrupt: " ++ name ++ " was non-string type: " ++ show rvt
+  where
+    sz = 512

--- a/src/Data/HodaTime/Pattern/CalendarDate.hs
+++ b/src/Data/HodaTime/Pattern/CalendarDate.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeOperators #-}
 module Data.HodaTime.Pattern.CalendarDate
 (
   -- * Standard Patterns

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-16.15
+resolver: lts-22.44
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This pull request modernizes Haskell and CI support for the project, updates Windows registry handling, and improves standards compliance in the `hodatime.cabal` file. The changes ensure compatibility with recent GHC versions, streamline the CI workflow, and fix issues with reading Windows registry values for time zones.

**CI modernization and GHC support:**

* Updated `.github/workflows/haskell.yml` to test across GHC 9.4–9.10 on Linux, and smoke-test the latest resolver on macOS and Windows. The workflow now uses `haskell-actions/setup@v2` for consistent Haskell toolchain setup, and simplifies caching logic.
* Added a dedicated cabal setup step to the publish job for GHC 9.6.7.
* Updated `tested-with` in `hodatime.cabal` to reflect support for GHC 9.4.8, 9.6.7, 9.8.4, and 9.10.3.
* Raised the lower bound of `base` to 4.16 and upper bound to <4.21 in `hodatime.cabal` for better compatibility with modern GHCs.

**Windows registry handling improvements:**

* Introduced a new `regQueryValueString` function in `platform/windows/Data/HodaTime/TimeZone/Platform.hs` to correctly read named string values (such as "Std", "Dlt", and "TimeZoneKeyName") from the registry, fixing prior incorrect usage of `regQueryValue`. Updated all relevant calls to use this new function. [[1]](diffhunk://#diff-e83e7ec85acea391a4016125ebc2d9c7625f0df6c1c554f03c210d460c2aa82cL21-R21) [[2]](diffhunk://#diff-e83e7ec85acea391a4016125ebc2d9c7625f0df6c1c554f03c210d460c2aa82cL116-R116) [[3]](diffhunk://#diff-e83e7ec85acea391a4016125ebc2d9c7625f0df6c1c554f03c210d460c2aa82cL132-R133) [[4]](diffhunk://#diff-e83e7ec85acea391a4016125ebc2d9c7625f0df6c1c554f03c210d460c2aa82cR172-R183)

**Standards compliance and minor improvements:**

* Set `cabal-version: 2.4` and updated the license field to `BSD-3-Clause` in `hodatime.cabal` for standards compliance.
* Enabled the `TypeOperators` language extension in `src/Data/HodaTime/Pattern/CalendarDate.hs` for future-proofing and consistency.